### PR TITLE
added provider agnostic database module

### DIFF
--- a/__e2e__/module.testing.ts
+++ b/__e2e__/module.testing.ts
@@ -11,7 +11,10 @@ class TestConfigService extends ConfigService {
       defid: {
         url: rpcUrl
       },
-      network: 'regtest'
+      network: 'regtest',
+      database: {
+        provider: 'memory'
+      }
     })
   }
 }

--- a/__sanity__/docker-compose.yml
+++ b/__sanity__/docker-compose.yml
@@ -35,3 +35,4 @@ services:
     environment:
       WHALE_DEFID_URL: http://whale-rpcuser:whale-rpcpassword@defi-blockchain:19554
       WHALE_NETWORK: regtest
+      WHALE_DATABASE_PROVIDER: memory

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@defichain/whale",
       "version": "0.0.0",
       "dependencies": {
-        "@defichain/jellyfish-api-core": "next",
-        "@defichain/jellyfish-api-jsonrpc": "next",
+        "@defichain/jellyfish-api-core": "^0.0.15",
+        "@defichain/jellyfish-api-jsonrpc": "^0.0.15",
         "@defichain/jellyfish-json": "next",
         "@nestjs/common": "^7.6.15",
         "@nestjs/config": "^0.6.3",
@@ -657,30 +657,19 @@
       }
     },
     "node_modules/@defichain/jellyfish-api-core": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-0.0.12.tgz",
-      "integrity": "sha512-e8hwwKrBTcV8ozh3hx/7WwdCxWspEsWgbQnfpA4y89TG70tbYPj/9utgetO8vV2De9yzQqpomSqldS3otwJAyQ==",
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-0.0.15.tgz",
+      "integrity": "sha512-25BuS++VwkxSLGw2y3E1z3qe4KmBouqTCbRhC2/Fa575emfKtb4HeUOqt2+6IoKAo6bC4K0ZUYzB0A/y8eLuIQ==",
       "dependencies": {
-        "@defichain/jellyfish-json": "^0.0.12"
-      }
-    },
-    "node_modules/@defichain/jellyfish-api-core/node_modules/@defichain/jellyfish-json": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-0.0.12.tgz",
-      "integrity": "sha512-ejrjhDsheo99dZZv0h3frN7LwiXotVcvAMoy0CScrux4mPh1oQ221mHrN+Ma5TXSWHPrkkYq4PK35lfhaGdU0g==",
-      "dependencies": {
-        "lossless-json": "^1.0.4"
-      },
-      "peerDependencies": {
-        "bignumber.js": "^9.0.1"
+        "@defichain/jellyfish-json": "^0.0.15"
       }
     },
     "node_modules/@defichain/jellyfish-api-jsonrpc": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-jsonrpc/-/jellyfish-api-jsonrpc-0.0.12.tgz",
-      "integrity": "sha512-vEb2rp9gWjELh0Ha074+RDPAWFFX+6yqnooF9hEGxPUTltWjb8MZNtMai+78+cYMOFmJGlNbckyQWYqxpd27mg==",
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-jsonrpc/-/jellyfish-api-jsonrpc-0.0.15.tgz",
+      "integrity": "sha512-4uQNnmKcJ1CYTTdphCDyDYPh7hbu7N9k2kmn3Jzovtq7eIRfHqVbSKcprf760Vz3hNs+rj2yhQ49pOWeSaHcNA==",
       "dependencies": {
-        "@defichain/jellyfish-api-core": "^0.0.12",
+        "@defichain/jellyfish-api-core": "^0.0.15",
         "abort-controller": "^3.0.0",
         "cross-fetch": "^3.1.2"
       }
@@ -12922,29 +12911,19 @@
       }
     },
     "@defichain/jellyfish-api-core": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-0.0.12.tgz",
-      "integrity": "sha512-e8hwwKrBTcV8ozh3hx/7WwdCxWspEsWgbQnfpA4y89TG70tbYPj/9utgetO8vV2De9yzQqpomSqldS3otwJAyQ==",
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-0.0.15.tgz",
+      "integrity": "sha512-25BuS++VwkxSLGw2y3E1z3qe4KmBouqTCbRhC2/Fa575emfKtb4HeUOqt2+6IoKAo6bC4K0ZUYzB0A/y8eLuIQ==",
       "requires": {
-        "@defichain/jellyfish-json": "^0.0.12"
-      },
-      "dependencies": {
-        "@defichain/jellyfish-json": {
-          "version": "0.0.12",
-          "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-0.0.12.tgz",
-          "integrity": "sha512-ejrjhDsheo99dZZv0h3frN7LwiXotVcvAMoy0CScrux4mPh1oQ221mHrN+Ma5TXSWHPrkkYq4PK35lfhaGdU0g==",
-          "requires": {
-            "lossless-json": "^1.0.4"
-          }
-        }
+        "@defichain/jellyfish-json": "^0.0.15"
       }
     },
     "@defichain/jellyfish-api-jsonrpc": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-jsonrpc/-/jellyfish-api-jsonrpc-0.0.12.tgz",
-      "integrity": "sha512-vEb2rp9gWjELh0Ha074+RDPAWFFX+6yqnooF9hEGxPUTltWjb8MZNtMai+78+cYMOFmJGlNbckyQWYqxpd27mg==",
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-jsonrpc/-/jellyfish-api-jsonrpc-0.0.15.tgz",
+      "integrity": "sha512-4uQNnmKcJ1CYTTdphCDyDYPh7hbu7N9k2kmn3Jzovtq7eIRfHqVbSKcprf760Vz3hNs+rj2yhQ49pOWeSaHcNA==",
       "requires": {
-        "@defichain/jellyfish-api-core": "^0.0.12",
+        "@defichain/jellyfish-api-core": "^0.0.15",
         "abort-controller": "^3.0.0",
         "cross-fetch": "^3.1.2"
       }

--- a/src/app.configuration.ts
+++ b/src/app.configuration.ts
@@ -2,5 +2,8 @@ export default (): any => ({
   defid: {
     url: process.env.WHALE_DEFID_URL
   },
-  network: process.env.WHALE_NETWORK
+  network: process.env.WHALE_NETWORK,
+  database: {
+    provider: process.env.WHALE_DATABASE_PROVIDER
+  }
 })

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import { ApiModule } from '@src/module.api'
 import { DeFiDModule } from '@src/module.defid'
 import configuration from '@src/app.configuration'
 import { HealthModule } from '@src/module.health'
+import { DatabaseModule } from '@src/module.database'
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { HealthModule } from '@src/module.health'
       load: [configuration]
     }),
     ScheduleModule.forRoot(),
+    DatabaseModule,
     DeFiDModule,
     HealthModule,
     ApiModule

--- a/src/module.database/database.ts
+++ b/src/module.database/database.ts
@@ -1,0 +1,7 @@
+export abstract class Database {
+  // TODO(fuxingloh): remove temporary implementation
+
+  abstract get (key: string): any
+
+  abstract put (key: string, data: any): void
+}

--- a/src/module.database/index.spec.ts
+++ b/src/module.database/index.spec.ts
@@ -1,0 +1,69 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { ConfigModule } from '@nestjs/config'
+import { DatabaseModule } from '@src/module.database'
+import { Database } from '@src/module.database/database'
+import { MemoryDatabase } from '@src/module.database/provider.memory/memory.database'
+
+describe('memory module', () => {
+  let app: TestingModule
+  let database: Database
+
+  beforeEach(async () => {
+    app = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({
+          isGlobal: true,
+          load: [() => ({
+            database: {
+              provider: 'memory'
+            }
+          })]
+        }),
+        DatabaseModule
+      ]
+    }).compile()
+
+    database = app.get<Database>(Database)
+  })
+
+  it('dynamically injected database should be memory database', () => {
+    expect(database instanceof MemoryDatabase).toBe(true)
+  })
+
+  it('should be a singleton module', () => {
+    expect(app.get<Database>(Database).get('1')).toBeFalsy()
+    expect(app.get<Database>(Database).get('2')).toBeFalsy()
+
+    app.get<Database>(Database).put('1', 'a-1')
+    app.get<Database>(Database).put('2', { b: 2 })
+
+    expect(app.get<Database>(Database).get('1')).toBe('a-1')
+    expect(app.get<Database>(Database).get('2')).toEqual({
+      b: 2
+    })
+  })
+})
+
+describe('invalid module', () => {
+  it('should fail module instantiation as database provider is invalid', async () => {
+    const initModule = async (): Promise<void> => {
+      await Test.createTestingModule({
+        imports: [
+          ConfigModule.forRoot({
+            isGlobal: true,
+            load: [() => ({
+              database: {
+                provider: 'invalid'
+              }
+            })]
+          }),
+          DatabaseModule
+        ]
+      }).compile()
+    }
+
+    await expect(initModule)
+      .rejects
+      .toThrow('bootstrapping error: invalid database.provider - invalid')
+  })
+})

--- a/src/module.database/index.ts
+++ b/src/module.database/index.ts
@@ -1,0 +1,42 @@
+import { ModuleRef } from '@nestjs/core'
+import { Global, Module } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import { FactoryProvider } from '@nestjs/common/interfaces/modules/provider.interface'
+import { Database } from '@src/module.database/database'
+import { MemoryDatabaseModule } from '@src/module.database/provider.memory'
+import { MemoryDatabase } from '@src/module.database/provider.memory/memory.database'
+
+/**
+ * Runtime DatabaseProvider, dynamically inject a database type based on config in the database.provider.
+ * @see Database
+ * @see MemoryDatabase
+ */
+const DatabaseProvider: FactoryProvider = {
+  provide: Database,
+  useFactory: async (configService: ConfigService, moduleRef: ModuleRef) => {
+    const provider = configService.get<string>('database.provider', '')
+    switch (provider) {
+      case 'memory':
+        return await moduleRef.create(MemoryDatabase)
+      default:
+        throw new Error(`bootstrapping error: invalid database.provider - ${provider}`)
+    }
+  },
+  inject: [ConfigService, ModuleRef]
+}
+
+/**
+ * DeFi Whale Database Module for service agnostic storage layer.
+ */
+@Global()
+@Module({
+  imports: [
+    MemoryDatabaseModule
+  ],
+  providers: [
+    DatabaseProvider
+  ],
+  exports: [Database]
+})
+export class DatabaseModule {
+}

--- a/src/module.database/provider.memory/index.ts
+++ b/src/module.database/provider.memory/index.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common'
+import { MemoryDatabase } from '@src/module.database/provider.memory/memory.database'
+
+/**
+ * Provides the memory database module where all data is stored in memory in NodeJS
+ */
+@Module({
+  providers: [
+    MemoryDatabase
+  ]
+})
+export class MemoryDatabaseModule {
+}

--- a/src/module.database/provider.memory/memory.database.ts
+++ b/src/module.database/provider.memory/memory.database.ts
@@ -1,0 +1,15 @@
+import { Database } from '@src/module.database/database'
+
+export class MemoryDatabase extends Database {
+  // TODO(fuxingloh): remove temporary implementation
+
+  private readonly records: Record<string, any> = {}
+
+  get (key: string): any {
+    return this.records[key]
+  }
+
+  put (key: string, data: any): void {
+    this.records[key] = data
+  }
+}


### PR DESCRIPTION

#### What kind of PR is this?:

/kind feature

#### What this PR does / why we need it:

This adds a provider agnostic database module that can be configured in `app.configuration.ts`
It allows configuration of database provider via env with `WHALE_DATABASE_PROVIDER: memory`.

An `Database` instance is provided at runtime by nestjs FactoryProvider.

https://github.com/DeFiCh/whale/blob/e507b2ecd1e4910a2a2946fc1d4a84b96f33d419/src/module.database/index.ts#L14-L26

The provider agnostic database modules is provided and registered at runtime but won't be initialized unless called upon.

https://github.com/DeFiCh/whale/blob/e507b2ecd1e4910a2a2946fc1d4a84b96f33d419/src/module.database/provider.memory/index.ts#L7-L13
