### PR TITLE
refactor config to use module export

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,11 +3,12 @@ const { compilerOptions } = require('./tsconfig')
 
 module.exports = {
   preset: 'ts-jest',
-  testRegex: '.*\\.spec|e2e\\.ts$',
+  testRegex: '.*\\.(spec|e2e)\\.ts$',
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, { prefix: '<rootDir>/' }),
   testTimeout: 180000,
   coveragePathIgnorePatterns: [
     '/node_modules/',
-    '.*/__e2e__/.*'
+    '.*/__e2e__/.*',
+    '.*/.*.spec/.*'
   ]
 }

--- a/src/app.configuration.ts
+++ b/src/app.configuration.ts
@@ -1,4 +1,10 @@
-export default (): any => ({
+/**
+ * AppConfiguration declares a dictionary for a deeply configurable DeFi whale setup.
+ * `process.env` resolves env variable at service initialization and allows setting of default.
+ * This configuration can be injected/replaced at runtime by overriding provider 'ConfigService' or
+ * replacing the config module.
+ */
+export const AppConfiguration = (): any => ({
   defid: {
     url: process.env.WHALE_DEFID_URL
   },

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,16 +3,16 @@ import { ConfigModule } from '@nestjs/config'
 import { ScheduleModule } from '@nestjs/schedule'
 
 import { ApiModule } from '@src/module.api'
-import { DeFiDModule } from '@src/module.defid'
-import configuration from '@src/app.configuration'
-import { HealthModule } from '@src/module.health'
 import { DatabaseModule } from '@src/module.database'
+import { DeFiDModule } from '@src/module.defid'
+import { HealthModule } from '@src/module.health'
+import { AppConfiguration } from '@src/app.configuration'
 
 @Module({
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
-      load: [configuration]
+      load: [AppConfiguration]
     }),
     ScheduleModule.forRoot(),
     DatabaseModule,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "strict": true,
     "module": "commonjs",
+    "esModuleInterop": true,
     "declaration": true,
     "removeComments": true,
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
#### What kind of PR is this?:
/kind refactor

#### What this PR does / why we need it:

Currently, config uses default export which is frowned upon on ES modules. Switched to use named module export. 

Also in this PR; 
1. fixed jest.config path picking up wrong tests
2. enabled esModuleInterop to use cjs packages
