### PR TITLE
whale-api-client: query pagination chaining

### DIFF
--- a/__e2e__/call.e2e.ts
+++ b/__e2e__/call.e2e.ts
@@ -19,7 +19,7 @@ afterAll(async () => {
 it('should 404 with invalid network', async () => {
   const res = await app.inject({
     method: 'POST',
-    url: '/v1/mainnet/call/getblockchaininfo'
+    url: '/v1/mainnet/rpc/getblockchaininfo'
   })
 
   expect(res.statusCode).toBe(404)
@@ -29,7 +29,7 @@ it('should 404 with invalid network', async () => {
       type: 'NotFound',
       at: expect.any(Number),
       message: 'Network not found',
-      url: '/v1/mainnet/call/getblockchaininfo'
+      url: '/v1/mainnet/rpc/getblockchaininfo'
     }
   })
 })
@@ -37,7 +37,7 @@ it('should 404 with invalid network', async () => {
 it('should 403 with non whitelisted method', async () => {
   const res = await app.inject({
     method: 'POST',
-    url: '/v1/regtest/call/getbalance'
+    url: '/v1/regtest/rpc/getbalance'
   })
 
   expect(res.statusCode).toBe(403)
@@ -47,7 +47,7 @@ it('should 403 with non whitelisted method', async () => {
       type: 'Forbidden',
       message: 'RPC method not whitelisted',
       at: expect.any(Number),
-      url: '/v1/regtest/call/getbalance'
+      url: '/v1/regtest/rpc/getbalance'
     }
   })
 })
@@ -55,7 +55,7 @@ it('should 403 with non whitelisted method', async () => {
 it('should 400 with invalid post body params', async () => {
   const res = await app.inject({
     method: 'POST',
-    url: '/v1/regtest/call/getblock',
+    url: '/v1/regtest/rpc/getblock',
     payload: {
       params: {
         block: 1
@@ -70,16 +70,16 @@ it('should 400 with invalid post body params', async () => {
       type: 'BadRequest',
       message: "RpcApiError: 'Unknown named parameter block', code: -8",
       at: expect.any(Number),
-      url: '/v1/regtest/call/getblock'
+      url: '/v1/regtest/rpc/getblock'
     }
   })
 })
 
 describe('whitelisted rpc methods', () => {
-  it('should 200 POST: /v1/regtest/call/getblockchaininfo', async () => {
+  it('should 200 POST: /v1/regtest/rpc/getblockchaininfo', async () => {
     const res = await app.inject({
       method: 'POST',
-      url: '/v1/regtest/call/getblockchaininfo'
+      url: '/v1/regtest/rpc/getblockchaininfo'
     })
 
     expect(res.statusCode).toBe(200)
@@ -90,10 +90,10 @@ describe('whitelisted rpc methods', () => {
     expect(typeof data.blocks).toBe('number')
   })
 
-  it('should 200 POST: /v1/regtest/call/getblockcount', async () => {
+  it('should 200 POST: /v1/regtest/rpc/getblockcount', async () => {
     const res = await app.inject({
       method: 'POST',
-      url: '/v1/regtest/call/getblockcount'
+      url: '/v1/regtest/rpc/getblockcount'
     })
 
     expect(res.statusCode).toBe(200)
@@ -103,7 +103,7 @@ describe('whitelisted rpc methods', () => {
     expect(typeof data).toBe('number')
   })
 
-  it('should 200 POST: /v1/regtest/call/getblockhash', async () => {
+  it('should 200 POST: /v1/regtest/rpc/getblockhash', async () => {
     await waitForExpect(async () => {
       const count = await container.call('getblockcount')
       await expect(count).toBeGreaterThan(1)
@@ -111,7 +111,7 @@ describe('whitelisted rpc methods', () => {
 
     const res = await app.inject({
       method: 'POST',
-      url: '/v1/regtest/call/getblockhash',
+      url: '/v1/regtest/rpc/getblockhash',
       payload: {
         params: [1]
       }
@@ -124,7 +124,7 @@ describe('whitelisted rpc methods', () => {
     expect(data.length).toBe(64)
   })
 
-  it('should 200 POST: /v1/regtest/call/getblock', async () => {
+  it('should 200 POST: /v1/regtest/rpc/getblock', async () => {
     await waitForExpect(async () => {
       const count = await container.call('getblockcount')
       await expect(count).toBeGreaterThan(1)
@@ -133,7 +133,7 @@ describe('whitelisted rpc methods', () => {
 
     const res = await app.inject({
       method: 'POST',
-      url: '/v1/regtest/call/getblock',
+      url: '/v1/regtest/rpc/getblock',
       payload: {
         params: [hash]
       }
@@ -147,3 +147,5 @@ describe('whitelisted rpc methods', () => {
     expect(Array.isArray(data.tx)).toBe(true)
   })
 })
+
+// TODO(fuxingloh): migrate test to packages/whale-api-client

--- a/__sanity__/postman_collection.json
+++ b/__sanity__/postman_collection.json
@@ -45,7 +45,7 @@
 			"response": []
 		},
 		{
-			"name": "/v1/regtest/call/getblockchaininfo",
+			"name": "/v1/regtest/rpc/getblockchaininfo",
 			"event": [
 				{
 					"listen": "test",
@@ -68,7 +68,7 @@
 				"method": "POST",
 				"header": [],
 				"url": {
-					"raw": "http://localhost:3000/v1/regtest/call/getblockchaininfo",
+					"raw": "http://localhost:3000/v1/regtest/rpc/getblockchaininfo",
 					"protocol": "http",
 					"host": [
 						"localhost"
@@ -77,7 +77,7 @@
 					"path": [
 						"v1",
 						"regtest",
-						"call",
+						"rpc",
 						"getblockchaininfo"
 					]
 				}
@@ -85,7 +85,7 @@
 			"response": []
 		},
 		{
-			"name": "/v1/regtest/call/getblockhash",
+			"name": "/v1/regtest/rpc/getblockhash",
 			"event": [
 				{
 					"listen": "test",
@@ -117,7 +117,7 @@
 					}
 				},
 				"url": {
-					"raw": "http://localhost:3000/v1/regtest/call/getblockhash",
+					"raw": "http://localhost:3000/v1/regtest/rpc/getblockhash",
 					"protocol": "http",
 					"host": [
 						"localhost"
@@ -126,7 +126,7 @@
 					"path": [
 						"v1",
 						"regtest",
-						"call",
+						"rpc",
 						"getblockhash"
 					]
 				}

--- a/packages/whale-api-client/__tests__/api/call.test.ts
+++ b/packages/whale-api-client/__tests__/api/call.test.ts
@@ -24,7 +24,7 @@ afterAll(async () => {
 })
 
 it("call('getblockchaininfo')", async () => {
-  const info = await client.call.call<blockchain.BlockchainInfo>('getblockchaininfo', [], 'number')
+  const info = await client.rpc.call<blockchain.BlockchainInfo>('getblockchaininfo', [], 'number')
 
   expect(info.chain).toBe('regtest')
   expect(typeof info.blocks).toBe('number')

--- a/packages/whale-api-client/__tests__/stub.client.ts
+++ b/packages/whale-api-client/__tests__/stub.client.ts
@@ -1,4 +1,4 @@
-import { Method, RawResponse, WhaleApiClient } from '../src'
+import { Method, ResponseAsString, WhaleApiClient } from '../src'
 import { StubService } from './stub.service'
 
 /**
@@ -10,7 +10,7 @@ export class StubWhaleApiClient extends WhaleApiClient {
     super({ url: 'not required' })
   }
 
-  protected async _fetch (method: Method, path: string, body: string, controller: AbortController): Promise<RawResponse> {
+  async requestAsString (method: Method, path: string, body?: string): Promise<ResponseAsString> {
     if (this.service.app === undefined) {
       throw new Error('StubService is not yet started.')
     }

--- a/packages/whale-api-client/src/api/call.ts
+++ b/packages/whale-api-client/src/api/call.ts
@@ -1,5 +1,6 @@
-import { ApiResponse, WhaleApiClient } from '../whale.api.client'
 import { JellyfishJSON, Precision, PrecisionPath } from '@defichain/jellyfish-api-core'
+import { WhaleApiClient } from '../whale.api.client'
+import { ApiResponse } from '../whale.api.response'
 import { raiseIfError } from '../errors'
 
 export class Call {
@@ -15,7 +16,7 @@ export class Call {
    */
   async call<T> (method: string, params: any[], precision: Precision | PrecisionPath): Promise<T> {
     const body = JellyfishJSON.stringify({ params: params })
-    const responseRaw = await this.client.requestRaw('POST', `call/${method}`, body)
+    const responseRaw = await this.client.requestAsString('POST', `call/${method}`, body)
     const response: ApiResponse<T> = JellyfishJSON.parse(responseRaw.body, precision)
     raiseIfError(response)
     return response.data

--- a/packages/whale-api-client/src/api/rpc.ts
+++ b/packages/whale-api-client/src/api/rpc.ts
@@ -3,7 +3,7 @@ import { WhaleApiClient } from '../whale.api.client'
 import { ApiResponse } from '../whale.api.response'
 import { raiseIfError } from '../errors'
 
-export class Call {
+export class Rpc {
   constructor (private readonly client: WhaleApiClient) {
   }
 
@@ -16,7 +16,7 @@ export class Call {
    */
   async call<T> (method: string, params: any[], precision: Precision | PrecisionPath): Promise<T> {
     const body = JellyfishJSON.stringify({ params: params })
-    const responseRaw = await this.client.requestAsString('POST', `call/${method}`, body)
+    const responseRaw = await this.client.requestAsString('POST', `rpc/${method}`, body)
     const response: ApiResponse<T> = JellyfishJSON.parse(responseRaw.body, precision)
     raiseIfError(response)
     return response.data

--- a/packages/whale-api-client/src/api/transactions.ts
+++ b/packages/whale-api-client/src/api/transactions.ts
@@ -5,23 +5,26 @@ export class Transactions {
   }
 
   /**
-   * @param {RawTxDto} rawTx to submit to the network.
+   * @param {RawTxReq} rawTx to submit to the network.
    * @throws WhaleApiException if failed mempool acceptance
    */
-  async send (rawTx: RawTxDto): Promise<string> {
+  async send (rawTx: RawTxReq): Promise<string> {
     return await this.client.requestData('POST', 'transactions', rawTx)
   }
 
   /**
-   * @param {RawTxDto} rawTx to test mempool acceptance
+   * @param {RawTxReq} rawTx to test mempool acceptance
    * @throws WhaleApiException if failed mempool acceptance
    */
-  async test (rawTx: RawTxDto): Promise<void> {
+  async test (rawTx: RawTxReq): Promise<void> {
     return await this.client.requestData('POST', 'transactions/test', rawTx)
   }
 }
 
-export interface RawTxDto {
+/**
+ * Raw transaction request
+ */
+export interface RawTxReq {
   hex: string
   maxFeeRate?: number
 }

--- a/packages/whale-api-client/src/api/transactions.ts
+++ b/packages/whale-api-client/src/api/transactions.ts
@@ -9,7 +9,7 @@ export class Transactions {
    * @throws WhaleApiException if failed mempool acceptance
    */
   async send (rawTx: RawTxDto): Promise<string> {
-    return await this.client.request('POST', 'transactions', rawTx)
+    return await this.client.requestData('POST', 'transactions', rawTx)
   }
 
   /**
@@ -17,7 +17,7 @@ export class Transactions {
    * @throws WhaleApiException if failed mempool acceptance
    */
   async test (rawTx: RawTxDto): Promise<void> {
-    return await this.client.request('POST', 'transactions/test', rawTx)
+    return await this.client.requestData('POST', 'transactions/test', rawTx)
   }
 }
 

--- a/packages/whale-api-client/src/errors/index.ts
+++ b/packages/whale-api-client/src/errors/index.ts
@@ -1,6 +1,6 @@
-import { ApiResponse } from '../whale.api.client'
 import { WhaleApiValidationException } from './api.validation.exception'
 import { WhaleApiErrorType, WhaleApiException } from './api.error'
+import { ApiResponse } from '../whale.api.response'
 
 export * from './api.validation.exception'
 export * from './api.error'

--- a/packages/whale-api-client/src/index.ts
+++ b/packages/whale-api-client/src/index.ts
@@ -1,7 +1,6 @@
 export * from './errors'
 
-export * as address from './api/address'
-export * as call from './api/call'
+export * as call from './api/rpc'
 export * as transactions from './api/transactions'
 
 export * from './whale.api.client'

--- a/packages/whale-api-client/src/index.ts
+++ b/packages/whale-api-client/src/index.ts
@@ -1,7 +1,9 @@
 export * from './errors'
 
+export * as address from './api/address'
 export * as call from './api/call'
 export * as transactions from './api/transactions'
 
 export * from './whale.api.client'
+export * from './whale.api.response'
 export * from './whale.rpc.client'

--- a/packages/whale-api-client/src/whale.api.client.ts
+++ b/packages/whale-api-client/src/whale.api.client.ts
@@ -2,7 +2,10 @@ import { Call } from './api/call'
 import { Transactions } from './api/transactions'
 import AbortController from 'abort-controller'
 import fetch from 'cross-fetch'
-import { raiseIfError, WhaleApiError, WhaleClientTimeoutException } from './errors'
+import { URLSearchParams } from 'url'
+import { raiseIfError, WhaleClientException, WhaleClientTimeoutException } from './errors'
+import { ApiResponse, ApiResponsePagination } from './whale.api.response'
+import { Address } from './api/address'
 
 /**
  * WhaleApiClient Options
@@ -37,27 +40,18 @@ export const DefaultOptions: WhaleApiClientOptions = {
   network: 'mainnet'
 }
 
-export interface ApiResponse<T> {
-  data: T
-  page?: ApiResponsePage
-  error?: WhaleApiError
-}
-
-export interface ApiResponsePage {
-  next?: string
-}
-
 /**
  * Supported REST Method for DeFi Whale
  */
 export type Method = 'POST' | 'GET'
 
-export interface RawResponse {
+export interface ResponseAsString {
   status: number
   body: string
 }
 
 export class WhaleApiClient {
+  public readonly address = new Address(this)
   public readonly call = new Call(this)
   public readonly transactions = new Transactions(this)
 
@@ -69,26 +63,87 @@ export class WhaleApiClient {
   }
 
   /**
+   * @param {ApiResponsePagination} response from the previous request for pagination chaining
+   */
+  async paginate<T> (response: ApiResponsePagination<T>): Promise<ApiResponsePagination<T>> {
+    const token = response.nextToken
+    if (token === undefined) {
+      return new ApiResponsePagination({ data: [] }, response.method, response.endpoint)
+    }
+
+    const [path, query] = response.endpoint.split('?')
+    if (query === undefined) {
+      throw new WhaleClientException('endpoint does not contain query params for pagination')
+    }
+
+    const params = new URLSearchParams(query)
+    params.set('next', token)
+    const endpoint = `${path}?${params.toString()}`
+
+    const apiResponse = await this.requestAsApiResponse<T[]>(response.method, endpoint)
+    return new ApiResponsePagination<T>(apiResponse, response.method, endpoint)
+  }
+
+  /**
    * @param {'POST|'GET'} method to request
    * @param {string} path to request
-   * @param {object} body to send in request
+   * @param {number} [size] of the list
+   * @param {string} [next] token for pagination
+   * @return {ApiResponsePagination} data list in the JSON response body for pagination query
+   * @see {paginate(ApiResponsePagination)} for pagination query chaining
    */
-  async request<T> (method: Method, path: string, body: object): Promise<T> {
-    const raw = await this.requestRaw(method, path, JSON.stringify(body))
-    const response: ApiResponse<T> = JSON.parse(raw.body)
-    raiseIfError(response)
+  async requestList<T> (method: Method, path: string, size: number, next?: string): Promise<ApiResponsePagination<T>> {
+    const params = new URLSearchParams()
+    params.set('size', `${size}`)
 
+    if (next !== undefined) {
+      params.set('next', next)
+    }
+
+    const response = await this.requestAsApiResponse<T[]>(method, `${path}?${params.toString()}`)
+    return new ApiResponsePagination<T>(response, method, path)
+  }
+
+  /**
+   * @param {'POST|'GET'} method to request
+   * @param {string} path to request
+   * @param {any} [object] JSON to send in request
+   * @return {T} data object in the JSON response body
+   */
+  async requestData<T> (method: Method, path: string, object?: any): Promise<T> {
+    const response = await this.requestAsApiResponse<T>(method, path, object)
     return response.data
   }
 
-  async requestRaw (method: Method, path: string, body: string): Promise<RawResponse> {
-    const { timeout } = this.options
+  /**
+   * @param {'POST|'GET'} method to request
+   * @param {string} path to request
+   * @param {object} [object] JSON to send in request
+   * @return {ApiResponse} parsed structured JSON response
+   */
+  async requestAsApiResponse<T> (method: Method, path: string, object?: any): Promise<ApiResponse<T>> {
+    const json = object !== undefined ? JSON.stringify(object) : undefined
+    const raw = await this.requestAsString(method, path, json)
+    const response: ApiResponse<T> = JSON.parse(raw.body)
+    raiseIfError(response)
+    return response
+  }
+
+  /**
+   * @param {'POST|'GET'} method to request
+   * @param {string} path to request
+   * @param {object} [body] in string in request
+   * @return {ResponseAsString} as JSON string (RawResponse)
+   */
+  async requestAsString (method: Method, path: string, body?: string): Promise<ResponseAsString> {
+    const { url: urlString, version, network, timeout } = this.options
+    const url = `${urlString}/${version as string}/${network as string}/${path}`
 
     const controller = new AbortController()
     const id = setTimeout(() => controller.abort(), timeout)
 
     try {
-      const response = await this._fetch(method, path, body, controller)
+      const response = await _fetch(method, url, controller, body)
       clearTimeout(id)
       return response
     } catch (err) {
@@ -100,24 +155,19 @@ export class WhaleApiClient {
       throw err
     }
   }
+}
 
-  protected async _fetch (method: Method, path: string, body: string, controller: AbortController): Promise<RawResponse> {
-    const { url, version, network } = this.options
+async function _fetch (method: Method, url: string, controller: AbortController, body?: string): Promise<ResponseAsString> {
+  const response = await fetch(url, {
+    method: method,
+    headers: { 'Content-Type': 'application/json' },
+    body: body,
+    cache: 'no-cache',
+    signal: controller.signal
+  })
 
-    const endpoint = `${url}/${version as string}/${network as string}/${path}`
-    const response = await fetch(endpoint, {
-      method: method,
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: body,
-      cache: 'no-cache',
-      signal: controller.signal
-    })
-
-    return {
-      status: response.status,
-      body: await response.text()
-    }
+  return {
+    status: response.status,
+    body: await response.text()
   }
 }

--- a/packages/whale-api-client/src/whale.api.client.ts
+++ b/packages/whale-api-client/src/whale.api.client.ts
@@ -1,11 +1,10 @@
-import { Call } from './api/call'
+import { Rpc } from './api/rpc'
 import { Transactions } from './api/transactions'
 import AbortController from 'abort-controller'
 import fetch from 'cross-fetch'
 import { URLSearchParams } from 'url'
 import { raiseIfError, WhaleClientException, WhaleClientTimeoutException } from './errors'
 import { ApiResponse, ApiResponsePagination } from './whale.api.response'
-import { Address } from './api/address'
 
 /**
  * WhaleApiClient Options
@@ -51,8 +50,7 @@ export interface ResponseAsString {
 }
 
 export class WhaleApiClient {
-  public readonly address = new Address(this)
-  public readonly call = new Call(this)
+  public readonly rpc = new Rpc(this)
   public readonly transactions = new Transactions(this)
 
   constructor (

--- a/packages/whale-api-client/src/whale.api.response.ts
+++ b/packages/whale-api-client/src/whale.api.response.ts
@@ -1,0 +1,64 @@
+import { WhaleApiError } from './errors'
+import { Method } from './whale.api.client'
+
+export interface ApiResponse<T> {
+  data: T
+  page?: ApiResponsePage
+  error?: WhaleApiError
+}
+
+export interface ApiResponsePage {
+  /**
+   * The next token for the next slice in the greater list.
+   */
+  next?: string
+}
+
+/**
+ * ApiResponsePagination class facilitate the ability to pagination query chaining.
+ * It extends the Array class and can be accessed like an array, `res[0]`, `res.length`.
+ *
+ * After accessing all the items in the Array, you can use the same ApiResponsePagination
+ * to query the next set of items. Hence allowing you query pagination chaining until you
+ * exhaustive all items in the list.
+ *
+ * @example
+ *   let response: ApiResponsePagination = await client.address.listTokens(...)
+ *   for (const item of response) {
+ *     console.log(item)
+ *   }
+ *
+ *   // To query next set of items:
+ *   let response = await client.pagination(response)
+ *   for (const item of response) {
+ *     console.log(item)
+ *   }
+ */
+export class ApiResponsePagination<T> extends Array<T> {
+  /**
+   * @param {ApiResponse} response that holds the data array and next token
+   * @param {Method} method of the REST endpoint
+   * @param {string} endpoint to paginate query
+   */
+  constructor (
+    public readonly response: ApiResponse<T[]>,
+    public readonly method: Method,
+    public readonly endpoint: string) {
+    super(response.data.length)
+    this.push(...response.data)
+  }
+
+  /**
+   * @return {boolean} whether there a next set of items to paginate
+   */
+  get hasNext (): boolean {
+    return this.nextToken !== undefined
+  }
+
+  /**
+   * @return {string} next token
+   */
+  get nextToken (): string | undefined {
+    return this.response.page?.next
+  }
+}

--- a/packages/whale-api-client/src/whale.rpc.client.ts
+++ b/packages/whale-api-client/src/whale.rpc.client.ts
@@ -31,6 +31,6 @@ export class WhaleRpcClient extends ApiClient {
    * @throws WhaleClientException instanceof for local issues
    */
   async call<T> (method: string, params: any[], precision: Precision | PrecisionPath): Promise<T> {
-    return await this.whaleApiClient.call.call(method, params, precision)
+    return await this.whaleApiClient.rpc.call(method, params, precision)
   }
 }

--- a/src/module.api/_module.ts
+++ b/src/module.api/_module.ts
@@ -1,6 +1,6 @@
 import { APP_PIPE } from '@nestjs/core'
 import { Module } from '@nestjs/common'
-import { CallController } from '@src/module.api/call.controller'
+import { RpcController } from '@src/module.api/rpc.controller'
 import { HealthController } from '@src/module.api/health.controller'
 import { TransactionsController } from '@src/module.api/transactions.controller'
 import { ApiValidationPipe } from '@src/module.api/_validation'
@@ -10,7 +10,7 @@ import { ApiValidationPipe } from '@src/module.api/_validation'
  */
 @Module({
   controllers: [
-    CallController,
+    RpcController,
     HealthController,
     TransactionsController
   ],

--- a/src/module.api/rpc.controller.spec.ts
+++ b/src/module.api/rpc.controller.spec.ts
@@ -1,12 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
 import { RegTestContainer } from '@defichain/testcontainers'
-import { CallController } from '@src/module.api/call.controller'
+import { RpcController } from '@src/module.api/rpc.controller'
 import { ConfigModule } from '@nestjs/config'
 
 const container = new RegTestContainer()
 let client: JsonRpcClient
-let controller: CallController
+let controller: RpcController
 
 beforeAll(async () => {
   await container.start()
@@ -23,11 +23,11 @@ beforeEach(async () => {
     imports: [ConfigModule.forRoot({
       load: [() => ({ network: 'regtest' })]
     })],
-    controllers: [CallController],
+    controllers: [RpcController],
     providers: [{ provide: JsonRpcClient, useFactory: () => client }]
   }).compile()
 
-  controller = app.get<CallController>(CallController)
+  controller = app.get<RpcController>(RpcController)
 })
 
 it('should getblockchaininfo', async () => {

--- a/src/module.api/rpc.controller.ts
+++ b/src/module.api/rpc.controller.ts
@@ -50,10 +50,10 @@ export class CallDto {
   params?: any[]
 }
 
-@Controller('/v1/:network/call')
+@Controller('/v1/:network/rpc')
 @UseGuards(NetworkGuard)
 @UseInterceptors(ResponseInterceptor, ExceptionInterceptor)
-export class CallController {
+export class RpcController {
   constructor (private readonly client: JsonRpcClient) {
   }
 


### PR DESCRIPTION
#### What kind of PR is this?:

/kind feature

#### What this PR does / why we need it:

This implements the final and last piece of specification, the 'query chaining pagination' specification. Together with https://github.com/DeFiCh/whale/pull/35 where we implement an LSM based slice querying pagination specification. This implements the interfacing layer for querying data in that design.

`ApiResponsePagination` class facilitate the ability to pagination query chaining. It extends the `Array` class that can be accessed like an array, `res[0]`, `res.length`. After accessing all the items in the Array, you can use the same `ApiResponsePagination` to query the next set of items. Hence allowing you query pagination chaining until you exhaust all items in the list.

This capability boils down to 

1. A unique endpoint that defines a uniquely sorted list (aka LSM Index) 
2. e.g. `/address/{address}/transactions` for a list of transactions in a LSM index.

for querying. A query-string specification for chaining:

1. `@Query('size') size: number`
2. `@Query('next') next?: string` 

for querying and;

1. `interface ApiResponse<T> { data: T, next?: ApiPage }`
2. `interface ApiPage { next?: string }` 

for next token carrying. Where consistency is key hence all querying/listing pattern must be.

In another word, allowing an `iterator` like querying for a list of items in a uniquely sorted index.
    
`WhaleApiClient` is written to natively support `client.paginate(response)` chaining. It also contains `client.requestList('GET', 'endpoint', size, next)` for initial querying.

```
As of writing, there isn't an endpoint that is pageable, hence I didn't write E2E test for it.
```

#### Implementation & Usage Example
```ts
@Controller('/v1/:network/address/:address')
@UseGuards(NetworkGuard)
@UseInterceptors(ResponseInterceptor, ExceptionInterceptor)
export class AddressController {

  @Get('/transactions')
  async listTransactions (
    @Param('address') address: string,
    @Query('size') size: number = 30,
    @Query('next') next?: string
  ): Promise<ApiSliceResponse<ScriptActivity>> {
    const items = await this.activityMapper.query(address, size, next)
    return ApiSliceResponse.of(items, size, item => {
      return item.id
    })
  }
  
}
```

```ts
export class Address {
  constructor (private readonly client: WhaleApiClient) {
  }

  async listTokens (address: string, size: number = 30, next?: string): Promise<ApiResponsePagination<string>> {
    return await this.client.requestList('GET', `address/${address}/tokens`, size, next)
  }

  async listTransactions (address: string, size: number = 30, next?: string): Promise<ApiResponsePagination<string>> {
    return await this.client.requestList('GET', `address/${address}/transactions`, size, next)
  }

  async listTransactionUnspent (address: string, size: number = 30, next?: string): Promise<ApiResponsePagination<string>> {
    return await this.client.requestList('GET', `address/${address}/transactions/unspent`, size, next)
  }
}
```

With that, you can query and chain request - response.

```ts
let response: ApiResponsePagination = await client.address.listTokens(...)
for (const item of response) {
 console.log(item)
}

// To query next set of items:
let response = await client.pagination(response)
for (const item of response) {
 console.log(item)
}
```
