### PR TITLE
'playground' keyword should not be part of whale distribution

### DIFF
--- a/packages/whale-api-client/src/whale.api.client.ts
+++ b/packages/whale-api-client/src/whale.api.client.ts
@@ -28,9 +28,8 @@ export interface WhaleApiClientOptions {
 
   /**
    * Network that whale client is configured to
-   * Playground is a special network for testing, see https://github.com/DeFiCh/playground
    */
-  network?: 'mainnet' | 'testnet' | 'regtest' | 'playground'
+  network?: 'mainnet' | 'testnet' | 'regtest'
 }
 
 /**

--- a/src/module.api/guards/network.guard.ts
+++ b/src/module.api/guards/network.guard.ts
@@ -15,8 +15,7 @@ export class NetworkGuard implements CanActivate {
   static available: string[] = [
     'mainnet',
     'testnet',
-    'regtest',
-    'playground'
+    'regtest'
   ]
 
   private readonly network: string


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

Network playground is not available in `defich/ain`, hence it should not be in whale either. When testing light wallet, I tried to use the 'playground' network to parse address to get balance but it wasn't supported as it's not a real network type.