### PR TITLE
fix typo in `LEVEL_UP_LOCATION`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ lerna-debug.log*
 
 # Level
 .level
+.leveldb

--- a/src/app.configuration.ts
+++ b/src/app.configuration.ts
@@ -5,6 +5,7 @@
  * replacing the config module.
  */
 export const AppConfiguration = (): any => ({
+  isProd: process.env.NODE_ENV === 'production',
   defid: {
     url: process.env.WHALE_DEFID_URL
   },

--- a/src/module.database/provider.level/module.ts
+++ b/src/module.database/provider.level/module.ts
@@ -19,11 +19,16 @@ function mkdir (location: string): void {
   providers: [
     {
       provide: 'LEVEL_UP_LOCATION',
+      /**
+       * if isProd, resolve to .leveldb/{network}
+       * else, resolve to .leveldb/{network}/time-now
+       */
       useFactory: (configService: ConfigService): string => {
-        const location = configService.get(
-          'database.level.location',
-          process.env.NODE_ENV === 'production ' ? '.level/index' : `.level/unnamed/${Date.now()}`
-        )
+        const isProd = configService.get<boolean>('isProd', false)
+        const network = configService.get<string>('network', 'unknown')
+        const defaultLocation = isProd ? `.leveldb/${network}` : `.leveldb/${network}/${Date.now()}`
+
+        const location = configService.get('database.level.location', defaultLocation)
         mkdir(location)
         return location
       },


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

```diff
-  'production '
+  'production'
```

Due to this, I moved `isProd` into the config service

By default in production and mainnet, it will default to `.leveldb/mainnet` if not provided with a level location.