### PR TITLE
fix ArrayConstructor for functional chaining

### DIFF
--- a/packages/whale-api-client/__tests__/whale.api.response.test.ts
+++ b/packages/whale-api-client/__tests__/whale.api.response.test.ts
@@ -38,3 +38,27 @@ it('should not have next', () => {
   expect(pagination.hasNext).toStrictEqual(false)
   expect(pagination.nextToken).toBeUndefined()
 })
+
+it('should be able to filter', () => {
+  const response: WhaleApiResponse<number[]> = {
+    data: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+  }
+
+  const pagination = new ApiPagedResponse(response, 'GET', '/items')
+
+  expect(pagination.filter(value => value % 2 === 0)).toStrictEqual([
+    0, 2, 4, 6, 8
+  ])
+})
+
+it('should be able to map', () => {
+  const response: WhaleApiResponse<number[]> = {
+    data: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+  }
+
+  const pagination = new ApiPagedResponse(response, 'GET', '/items')
+
+  expect(pagination.map(value => value * 11)).toStrictEqual([
+    0, 11, 22, 33, 44, 55, 66, 77, 88, 99
+  ])
+})

--- a/packages/whale-api-client/src/whale.api.response.ts
+++ b/packages/whale-api-client/src/whale.api.response.ts
@@ -59,6 +59,15 @@ export class ApiPagedResponse<T> extends Array<T> {
   }
 
   /**
+   * Built-in methods such as map, filter creates a new array for functional programming.
+   * It does that with the constructor found in the static Symbol.species class property.
+   * This needs to be overridden as ApiPagedResponse constructor has a different signature.
+   */
+  static get [Symbol.species] (): ArrayConstructor {
+    return Array
+  }
+
+  /**
    * @return {string} endpoint to paginate query
    */
   get endpoint (): string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

Built-in methods such as map, the filter creates a new array for functional programming. It does that with the constructor found in the static `Symbol.species` class property. This needs to be overridden as `ApiPagedResponse` constructor has a different signature.
