### PR TITLE
removed illegal `import { HttpStatus } from '@nestjs/common'` in packages

### DIFF
--- a/packages/whale-api-client/src/errors/api.error.ts
+++ b/packages/whale-api-client/src/errors/api.error.ts
@@ -1,5 +1,3 @@
-import { HttpStatus } from '@nestjs/common'
-
 export enum WhaleApiErrorType {
   ValidationError = 'ValidationError',
   BadRequest = 'BadRequest',
@@ -13,7 +11,7 @@ export enum WhaleApiErrorType {
 }
 
 export interface WhaleApiError {
-  code: HttpStatus
+  code: number
   type: WhaleApiErrorType
   at: number
   message?: string


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

removed illegal `import { HttpStatus } from '@nestjs/common'` in packages
