### PR TITLE
rename _health to _actuator to allow more features to be added for service controllability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         run: docker-compose -f __sanity__/docker-compose.yml up -d
 
       - name: Wait for
-        run: ./__sanity__/wait-for http://localhost:3000/_health/probes/liveness -t 6
+        run: ./__sanity__/wait-for http://localhost:3000/_actuator/probes/liveness -t 6
 
       - name: Sanity testing
         uses: matt-ball/newman-action@0659e9b8d056c0d03d94e1dbfce380512088b566

--- a/__sanity__/postman_collection.json
+++ b/__sanity__/postman_collection.json
@@ -6,7 +6,7 @@
 	},
 	"item": [
 		{
-			"name": "/_health/probes/liveness",
+			"name": "/_actuator/probes/liveness",
 			"event": [
 				{
 					"listen": "test",
@@ -29,14 +29,14 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "http://localhost:3000/_health/probes/liveness",
+					"raw": "http://localhost:3000/_actuator/probes/liveness",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
 					"port": "3000",
 					"path": [
-						"_health",
+						"_actuator",
 						"probes",
 						"liveness"
 					]

--- a/src/module.api/_module.ts
+++ b/src/module.api/_module.ts
@@ -1,7 +1,7 @@
 import { APP_GUARD, APP_INTERCEPTOR, APP_PIPE } from '@nestjs/core'
 import { CacheModule, Module } from '@nestjs/common'
 import { RpcController } from '@src/module.api/rpc.controller'
-import { HealthController } from '@src/module.api/health.controller'
+import { ActuatorController } from '@src/module.api/actuator.controller'
 import { TransactionsController } from '@src/module.api/transaction.controller'
 import { ApiValidationPipe } from '@src/module.api/pipes/api.validation.pipe'
 import { AddressController } from '@src/module.api/address.controller'
@@ -20,7 +20,7 @@ import { TokensController } from '@src/module.api/token.controller'
   controllers: [
     RpcController,
     AddressController,
-    HealthController,
+    ActuatorController,
     TransactionsController,
     TokensController,
     PoolPairController

--- a/src/module.api/actuator.controller.ts
+++ b/src/module.api/actuator.controller.ts
@@ -2,8 +2,8 @@ import { Controller, Get } from '@nestjs/common'
 import { HealthCheck, HealthCheckResult, HealthCheckService } from '@nestjs/terminus'
 import { DeFiDProbeIndicator } from '@src/module.defid/defid.indicator'
 
-@Controller('/_health')
-export class HealthController {
+@Controller('/_actuator')
+export class ActuatorController {
   constructor (
     private readonly health: HealthCheckService,
     private readonly defid: DeFiDProbeIndicator) {
@@ -34,4 +34,7 @@ export class HealthController {
       async () => await this.defid.readiness()
     ])
   }
+
+  // TODO(fuxingloh): /_actuator/stop
+  // TODO(fuxingloh): /_actuator/probes/syncing
 }

--- a/src/module.api/actuator.e2e.ts
+++ b/src/module.api/actuator.e2e.ts
@@ -19,11 +19,11 @@ afterAll(async () => {
   }
 })
 
-describe('/_health/probes/liveness', () => {
+describe('/_actuator/probes/liveness', () => {
   it('should wait until liveness', async () => {
     const res = await app.inject({
       method: 'GET',
-      url: '/_health/probes/liveness'
+      url: '/_actuator/probes/liveness'
     })
 
     expect(res.statusCode).toStrictEqual(200)
@@ -44,13 +44,13 @@ describe('/_health/probes/liveness', () => {
   })
 })
 
-describe('/_health/probes/readiness', () => {
-  // TODO(fuxingloh): /_health/probes/readiness tests for it to be ready
+describe('/_actuator/probes/readiness', () => {
+  // TODO(fuxingloh): /_actuator/probes/readiness tests for it to be ready
 
   it('should wait until readiness, but never will be as it lacks connections', async () => {
     const res = await app.inject({
       method: 'GET',
-      url: '/_health/probes/readiness'
+      url: '/_actuator/probes/readiness'
     })
 
     expect(res.statusCode).toStrictEqual(503)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:

Rename `/_health/*` to`/ _actuator/*` to allow more features to be added for service controllability. 
