### PR TITLE
updated defid probes to 'not connected to any peer'

### DIFF
--- a/src/module.defid/defid.probes.ts
+++ b/src/module.defid/defid.probes.ts
@@ -49,8 +49,8 @@ export class DeFiDProbeIndicator extends ProbeIndicator {
       return this.withDead('defid', 'defid in initial block download', details)
     }
 
-    if (peers < 5) {
-      return this.withDead('defid', `defid is connected to only ${peers} <5 peers`, details)
+    if (peers === 0) {
+      return this.withDead('defid', 'defid is not connected to any peer', details)
     }
 
     return this.withAlive('defid')


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

- `defid` or `bitcoind` does not provide the ability to set a minimum number of peers to keep alive. 
- Having min peer of 5 (or any threshold) is still dangerous during a network cascade event as it will kill off basically all services when it dip below that threshold.