### PR TITLE
added withTransactionBuilder for WhaleWalletAccount to use Whale feeRate and prevout provider

### DIFF
--- a/packages/whale-api-wallet/src/wallet.ts
+++ b/packages/whale-api-wallet/src/wallet.ts
@@ -1,16 +1,30 @@
 import { WalletAccount, WalletAccountProvider, WalletHdNode } from '@defichain/jellyfish-wallet'
 import { WhaleApiClient } from '@defichain/whale-api-client'
 import { Network } from '@defichain/jellyfish-network'
+import { P2WPKHTransactionBuilder } from '@defichain/jellyfish-transaction-builder/dist'
+import { WhaleFeeRateProvider } from './feerate'
+import { WhalePrevoutProvider } from './prevout'
 
 export class WhaleWalletAccount extends WalletAccount {
-  constructor (public readonly client: WhaleApiClient, hdNode: WalletHdNode, network: Network) {
+  protected readonly feeRateProvider: WhaleFeeRateProvider
+  protected readonly prevoutProvider: WhalePrevoutProvider
+
+  constructor (public readonly client: WhaleApiClient, hdNode: WalletHdNode, network: Network, prevoutSize: number = 50) {
     super(hdNode, network)
+    this.feeRateProvider = new WhaleFeeRateProvider(client)
+    this.prevoutProvider = new WhalePrevoutProvider(this, prevoutSize)
   }
 
   async isActive (): Promise<boolean> {
     const address = await this.getAddress()
     const agg = await this.client.address.getAggregation(address)
     return agg !== undefined
+  }
+
+  withTransactionBuilder (): P2WPKHTransactionBuilder {
+    return new P2WPKHTransactionBuilder(this.feeRateProvider, this.prevoutProvider, {
+      get: (_) => this
+    })
   }
 }
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:

Added withTransactionBuilder for WhaleWalletAccount to use Whale fee rate and prevout provider. This makes it easier to use craft a transaction with `whale-api-wallet`.