### PR TITLE
Bump jellyfish deps to v0.24.0 with `WalletEllipticPair` update

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,8 +6,8 @@
 /.idea/                                         @fuxingloh
 
 /packages/                                      @fuxingloh
-/packages/whale-api-client/                     @fuxingloh @canonbrother @jingyi2811
-/packages/whale-api-wallet/                     @fuxingloh @ivan-zynesis
+/packages/whale-api-client/                     @fuxingloh @canonbrother @jingyi2811 @ivan-zynesis @thedoublejay @monstrobishi
+/packages/whale-api-wallet/                     @fuxingloh @ivan-zynesis @thedoublejay @monstrobishi
 
 /src/                                           @fuxingloh
 /src/module.api/                                @fuxingloh @canonbrother @jingyi2811

--- a/.idea/whale.iml
+++ b/.idea/whale.iml
@@ -4,6 +4,8 @@
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <excludePattern pattern="*dist*" />
+      <excludePattern pattern="*.level*" />
+      <excludePattern pattern="*.leveldb*" />
     </content>
     <orderEntry type="sourceFolder" forTests="false" />
   </component>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,12 @@
         "./packages/*"
       ],
       "dependencies": {
-        "@defichain/jellyfish-address": ">=0.22.0",
-        "@defichain/jellyfish-api-core": ">=0.22.0",
-        "@defichain/jellyfish-api-jsonrpc": ">=0.22.0",
-        "@defichain/jellyfish-json": ">=0.22.0",
-        "@defichain/jellyfish-network": ">=0.22.0",
-        "@defichain/jellyfish-transaction": ">=0.22.0",
+        "@defichain/jellyfish-address": ">=0.24.0",
+        "@defichain/jellyfish-api-core": ">=0.24.0",
+        "@defichain/jellyfish-api-jsonrpc": ">=0.24.0",
+        "@defichain/jellyfish-json": ">=0.24.0",
+        "@defichain/jellyfish-network": ">=0.24.0",
+        "@defichain/jellyfish-transaction": ">=0.24.0",
         "@nestjs/common": "^7.6.15",
         "@nestjs/config": "^0.6.3",
         "@nestjs/core": "^7.6.15",
@@ -36,9 +36,9 @@
         "subleveldown": "^5.0.1"
       },
       "devDependencies": {
-        "@defichain/jellyfish-crypto": ">=0.22.0",
-        "@defichain/testcontainers": ">=0.22.0",
-        "@defichain/testing": ">=0.22.0",
+        "@defichain/jellyfish-crypto": ">=0.24.0",
+        "@defichain/testcontainers": ">=0.24.0",
+        "@defichain/testing": ">=0.24.0",
         "@nestjs/cli": "^7.6.0",
         "@nestjs/schematics": "^7.3.0",
         "@nestjs/testing": "^7.6.15",
@@ -679,38 +679,38 @@
       }
     },
     "node_modules/@defichain/jellyfish-address": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-address/-/jellyfish-address-0.22.0.tgz",
-      "integrity": "sha512-NqlONt0Vkp5nmvg3glxmDWy7boZdyal5/wP55FNJEyDfS4IxpA3sv+GYIDJe2M/u4HFud/lEm6sPnjyT466y4A==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-address/-/jellyfish-address-0.24.0.tgz",
+      "integrity": "sha512-ajNOtErVlq8K/3oT6RDSByXQNaa3zIUzBSqjT9f+rKpXcm1ToEzRsvIulrr6A37kwu/h/VW3zHaI6ew9E8/MiA==",
       "dependencies": {
-        "@defichain/jellyfish-crypto": "^0.22.0",
-        "@defichain/jellyfish-network": "^0.22.0",
-        "@defichain/jellyfish-transaction": "^0.22.0",
+        "@defichain/jellyfish-crypto": "^0.24.0",
+        "@defichain/jellyfish-network": "^0.24.0",
+        "@defichain/jellyfish-transaction": "^0.24.0",
         "bs58": "^4.0.1"
       }
     },
     "node_modules/@defichain/jellyfish-api-core": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-0.22.0.tgz",
-      "integrity": "sha512-Fn6vFsu+ujgG8xtaFll2liP8oGtqhTxbjEk86VeOXEV7I5VT7XD7uI/GJyt72wLTheOBwDLEL/nPuC4QmykrOg==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-0.24.0.tgz",
+      "integrity": "sha512-V14Pz6SNTVSWZqjLMmhFE6Q7KRztPVFh9JrOzrrzbq0eOZoIlC4OReOrCtBnevkfszDmtfJsSf20LD3rl8Aycw==",
       "dependencies": {
-        "@defichain/jellyfish-json": "^0.22.0"
+        "@defichain/jellyfish-json": "^0.24.0"
       }
     },
     "node_modules/@defichain/jellyfish-api-jsonrpc": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-jsonrpc/-/jellyfish-api-jsonrpc-0.22.0.tgz",
-      "integrity": "sha512-hoViSHp6R62sSN2957jnfiQPMlO99FydvnpofUxcxdq5KlqIHKJfqSk/ljM26M/SiLpymItsQLOd7ek3gHPFRg==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-jsonrpc/-/jellyfish-api-jsonrpc-0.24.0.tgz",
+      "integrity": "sha512-zQbwZBlu3nzhsVn/pZy+ffBjO3KXV9E+zp6Lco28ICa2lADASJt/GKeaXdnBsP6bI2u8bfNfat8OOcIZX23h9w==",
       "dependencies": {
-        "@defichain/jellyfish-api-core": "^0.22.0",
+        "@defichain/jellyfish-api-core": "^0.24.0",
         "abort-controller": "^3.0.0",
         "cross-fetch": "^3.1.2"
       }
     },
     "node_modules/@defichain/jellyfish-crypto": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-crypto/-/jellyfish-crypto-0.22.0.tgz",
-      "integrity": "sha512-z//t95bEE4a/PHvma/QKKY5PbOMxF4CYJHm4eiN60fRhD7xffYz6RZs6XqvAQVYxbejhMVaFRC/AhCRA6BGxfw==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-crypto/-/jellyfish-crypto-0.24.0.tgz",
+      "integrity": "sha512-B0U+NPhxerTIp22RWLndktsG2d9U3A/1m8iGdkVHEZ9P3joQ9/GZtgrkgAhKDLfPryJbkLeVe0YS2hqCaah45Q==",
       "dependencies": {
         "bech32": "^2.0.0",
         "bip66": "^1.1.5",
@@ -723,9 +723,9 @@
       }
     },
     "node_modules/@defichain/jellyfish-json": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-0.22.0.tgz",
-      "integrity": "sha512-JH0lqhGFfbH3WbegtJOQYcmHAPnCPe1xzm8LTk1WmnzeAAmTdvac4ABDkwtg2VnoepzcLzna0VWUKidX/XqLIg==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-0.24.0.tgz",
+      "integrity": "sha512-BbWqLFY4/5lVtaRSH/qVNPVnJrWBPeVDeTcj7XpML33mBVj03BgGn1vNPKaL69MugFmIfieMVHWGVxaxeDMFrw==",
       "dependencies": {
         "@types/lossless-json": "^1.0.0",
         "lossless-json": "^1.0.4"
@@ -735,16 +735,16 @@
       }
     },
     "node_modules/@defichain/jellyfish-network": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-network/-/jellyfish-network-0.22.0.tgz",
-      "integrity": "sha512-iLpkyeyLBKIuYQUq+284dSAgl8ppe8icEogEY4mG3A8QHDhmAE0MJdFp8ckF/2SjdIkV49iWu6MPNfcF9qjgNA=="
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-network/-/jellyfish-network-0.24.0.tgz",
+      "integrity": "sha512-dqj1bVAK/TPi+No2Zolj6ElV8XPSo54gOt7b39FzRjc9WSjpn2nZrJAboGs6+9LFrpxPt5S+maoYQxuOcqbQFg=="
     },
     "node_modules/@defichain/jellyfish-transaction": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction/-/jellyfish-transaction-0.22.0.tgz",
-      "integrity": "sha512-feNTv6EtW54IOStFYi3hGB0TcYzkt7zZ3V62soTUzeyojIHvTWCtUJnRT4oQcQiMQJkIRXlbVH6FbI5SFkaT8g==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction/-/jellyfish-transaction-0.24.0.tgz",
+      "integrity": "sha512-WdlT5gS7gpK+kCrlBSXvJGLYQBAwlWZPzr2byaHMU366wOCNnjMaTbG3I4h9VAi/dKLE6r9MNVYru3WqJYnkaQ==",
       "dependencies": {
-        "@defichain/jellyfish-crypto": "^0.22.0",
+        "@defichain/jellyfish-crypto": "^0.24.0",
         "smart-buffer": "^4.1.0"
       },
       "peerDependencies": {
@@ -752,25 +752,25 @@
       }
     },
     "node_modules/@defichain/jellyfish-transaction-builder": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction-builder/-/jellyfish-transaction-builder-0.22.0.tgz",
-      "integrity": "sha512-mok4fAnoFW99q1molE3ss36aaHYOo2ugbLJDT5OzzoJMz0vLIgM7wxmEzIWu7hgR6KsL/AU9MkJFN11QpOcnHg==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction-builder/-/jellyfish-transaction-builder-0.24.0.tgz",
+      "integrity": "sha512-3iRlbAaqyfqaTmjLBXelTlFKMAhqioDF1j1OqQnXxLQrj83kMhI5jCSrhtcALjobQHqxCIP7uurfwpehRd18lA==",
       "dependencies": {
-        "@defichain/jellyfish-crypto": "^0.22.0",
-        "@defichain/jellyfish-transaction": "^0.22.0",
-        "@defichain/jellyfish-transaction-signature": "^0.22.0"
+        "@defichain/jellyfish-crypto": "^0.24.0",
+        "@defichain/jellyfish-transaction": "^0.24.0",
+        "@defichain/jellyfish-transaction-signature": "^0.24.0"
       },
       "peerDependencies": {
         "bignumber.js": "^9.0.1"
       }
     },
     "node_modules/@defichain/jellyfish-transaction-signature": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction-signature/-/jellyfish-transaction-signature-0.22.0.tgz",
-      "integrity": "sha512-+ilAcorkCCVpJ+aeN6bJ+Eve2c6A6TisJkC+RZdGYo/gGjtGVSInaZ0qwJh01Cx/ce06XRqkL5b+1WQTjajnCQ==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction-signature/-/jellyfish-transaction-signature-0.24.0.tgz",
+      "integrity": "sha512-uMHm7OPX0qDtiUWbwC16+7V3Jgg0rZeZxnxRpdZ7qh/lWhaxpIwUIOUhwBv0mCNi4LOZFDhDvpvL91SqaYs9+w==",
       "dependencies": {
-        "@defichain/jellyfish-crypto": "^0.22.0",
-        "@defichain/jellyfish-transaction": "^0.22.0",
+        "@defichain/jellyfish-crypto": "^0.24.0",
+        "@defichain/jellyfish-transaction": "^0.24.0",
         "smart-buffer": "^4.1.0"
       },
       "peerDependencies": {
@@ -778,23 +778,23 @@
       }
     },
     "node_modules/@defichain/jellyfish-wallet": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-wallet/-/jellyfish-wallet-0.22.0.tgz",
-      "integrity": "sha512-3BGgmVDBo4ZKUgGYX8P+F9c9DTxAS1CVzEgL/mLI816Nas3pkyBEL4nO764bu1+lrHEqGVi58BVF/7mQw4Z1ig==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-wallet/-/jellyfish-wallet-0.24.0.tgz",
+      "integrity": "sha512-64YL/jrDjIoy/N9qvuVBt4UREoeWr+uzW8IPJfCDNvCHR90sm+xzKJiFjoW9qrSB8pXh06SWluuFnXFjNV0I+g==",
       "dependencies": {
-        "@defichain/jellyfish-address": "^0.22.0",
-        "@defichain/jellyfish-crypto": "^0.22.0",
-        "@defichain/jellyfish-network": "^0.22.0",
-        "@defichain/jellyfish-transaction": "^0.22.0"
+        "@defichain/jellyfish-address": "^0.24.0",
+        "@defichain/jellyfish-crypto": "^0.24.0",
+        "@defichain/jellyfish-network": "^0.24.0",
+        "@defichain/jellyfish-transaction": "^0.24.0"
       },
       "peerDependencies": {
         "bignumber.js": "^9.0.1"
       }
     },
     "node_modules/@defichain/testcontainers": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@defichain/testcontainers/-/testcontainers-0.22.0.tgz",
-      "integrity": "sha512-uVb5SSFHo0IXeiRI/SiwJyGb6gMd0O7iu5FMBEJiqSYxbclUBBtBcQgCjvl1SAPYLVSCiNXnur+O/mOWnk7KAQ==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@defichain/testcontainers/-/testcontainers-0.24.0.tgz",
+      "integrity": "sha512-rg7P7/gOnXe1j636AO0pyCv9XYYY478mNW8jbllZMuW26ZbHbiwImIVx1Us5WFaqtjzryAATnV8RD4bWOabYMA==",
       "dev": true,
       "dependencies": {
         "dockerode": "^3.3.0",
@@ -802,15 +802,15 @@
       }
     },
     "node_modules/@defichain/testing": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@defichain/testing/-/testing-0.22.0.tgz",
-      "integrity": "sha512-mMn/eT208OFp0VwEpqEpAGunHv6A0DF4mutELiboOQPgil5ifQFtt36KJBq194heOfZWwvCU9hWkpIRDmLp6Ew==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@defichain/testing/-/testing-0.24.0.tgz",
+      "integrity": "sha512-zw37Pr+mUv1mTaQYWogQYgUF01sv48dvexw885dRzCapvaChc8a9aRRFNvw7/MuydRExKuWrAWJ2hZIj7atONw==",
       "dev": true,
       "dependencies": {
-        "@defichain/jellyfish-api-core": "^0.22.0",
-        "@defichain/jellyfish-crypto": "^0.22.0",
-        "@defichain/jellyfish-network": "^0.22.0",
-        "@defichain/testcontainers": "^0.22.0"
+        "@defichain/jellyfish-api-core": "^0.24.0",
+        "@defichain/jellyfish-crypto": "^0.24.0",
+        "@defichain/jellyfish-network": "^0.24.0",
+        "@defichain/testcontainers": "^0.24.0"
       }
     },
     "node_modules/@defichain/whale-api-client": {
@@ -18383,7 +18383,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@defichain/jellyfish-api-core": ">=0.22.0",
+        "@defichain/jellyfish-api-core": ">=0.24.0",
         "abort-controller": "^3.0.0",
         "cross-fetch": "^3.1.2",
         "url-search-params-polyfill": "8.1.1"
@@ -18394,8 +18394,8 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@defichain/jellyfish-transaction-builder": ">=0.22.0",
-        "@defichain/jellyfish-wallet": ">=0.22.0",
+        "@defichain/jellyfish-transaction-builder": ">=0.24.0",
+        "@defichain/jellyfish-wallet": ">=0.24.0",
         "@defichain/whale-api-client": "0.0.0"
       }
     },
@@ -18926,38 +18926,38 @@
       }
     },
     "@defichain/jellyfish-address": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-address/-/jellyfish-address-0.22.0.tgz",
-      "integrity": "sha512-NqlONt0Vkp5nmvg3glxmDWy7boZdyal5/wP55FNJEyDfS4IxpA3sv+GYIDJe2M/u4HFud/lEm6sPnjyT466y4A==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-address/-/jellyfish-address-0.24.0.tgz",
+      "integrity": "sha512-ajNOtErVlq8K/3oT6RDSByXQNaa3zIUzBSqjT9f+rKpXcm1ToEzRsvIulrr6A37kwu/h/VW3zHaI6ew9E8/MiA==",
       "requires": {
-        "@defichain/jellyfish-crypto": "^0.22.0",
-        "@defichain/jellyfish-network": "^0.22.0",
-        "@defichain/jellyfish-transaction": "^0.22.0",
+        "@defichain/jellyfish-crypto": "^0.24.0",
+        "@defichain/jellyfish-network": "^0.24.0",
+        "@defichain/jellyfish-transaction": "^0.24.0",
         "bs58": "^4.0.1"
       }
     },
     "@defichain/jellyfish-api-core": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-0.22.0.tgz",
-      "integrity": "sha512-Fn6vFsu+ujgG8xtaFll2liP8oGtqhTxbjEk86VeOXEV7I5VT7XD7uI/GJyt72wLTheOBwDLEL/nPuC4QmykrOg==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-0.24.0.tgz",
+      "integrity": "sha512-V14Pz6SNTVSWZqjLMmhFE6Q7KRztPVFh9JrOzrrzbq0eOZoIlC4OReOrCtBnevkfszDmtfJsSf20LD3rl8Aycw==",
       "requires": {
-        "@defichain/jellyfish-json": "^0.22.0"
+        "@defichain/jellyfish-json": "^0.24.0"
       }
     },
     "@defichain/jellyfish-api-jsonrpc": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-jsonrpc/-/jellyfish-api-jsonrpc-0.22.0.tgz",
-      "integrity": "sha512-hoViSHp6R62sSN2957jnfiQPMlO99FydvnpofUxcxdq5KlqIHKJfqSk/ljM26M/SiLpymItsQLOd7ek3gHPFRg==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-jsonrpc/-/jellyfish-api-jsonrpc-0.24.0.tgz",
+      "integrity": "sha512-zQbwZBlu3nzhsVn/pZy+ffBjO3KXV9E+zp6Lco28ICa2lADASJt/GKeaXdnBsP6bI2u8bfNfat8OOcIZX23h9w==",
       "requires": {
-        "@defichain/jellyfish-api-core": "^0.22.0",
+        "@defichain/jellyfish-api-core": "^0.24.0",
         "abort-controller": "^3.0.0",
         "cross-fetch": "^3.1.2"
       }
     },
     "@defichain/jellyfish-crypto": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-crypto/-/jellyfish-crypto-0.22.0.tgz",
-      "integrity": "sha512-z//t95bEE4a/PHvma/QKKY5PbOMxF4CYJHm4eiN60fRhD7xffYz6RZs6XqvAQVYxbejhMVaFRC/AhCRA6BGxfw==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-crypto/-/jellyfish-crypto-0.24.0.tgz",
+      "integrity": "sha512-B0U+NPhxerTIp22RWLndktsG2d9U3A/1m8iGdkVHEZ9P3joQ9/GZtgrkgAhKDLfPryJbkLeVe0YS2hqCaah45Q==",
       "requires": {
         "bech32": "^2.0.0",
         "bip66": "^1.1.5",
@@ -18970,63 +18970,63 @@
       }
     },
     "@defichain/jellyfish-json": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-0.22.0.tgz",
-      "integrity": "sha512-JH0lqhGFfbH3WbegtJOQYcmHAPnCPe1xzm8LTk1WmnzeAAmTdvac4ABDkwtg2VnoepzcLzna0VWUKidX/XqLIg==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-0.24.0.tgz",
+      "integrity": "sha512-BbWqLFY4/5lVtaRSH/qVNPVnJrWBPeVDeTcj7XpML33mBVj03BgGn1vNPKaL69MugFmIfieMVHWGVxaxeDMFrw==",
       "requires": {
         "@types/lossless-json": "^1.0.0",
         "lossless-json": "^1.0.4"
       }
     },
     "@defichain/jellyfish-network": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-network/-/jellyfish-network-0.22.0.tgz",
-      "integrity": "sha512-iLpkyeyLBKIuYQUq+284dSAgl8ppe8icEogEY4mG3A8QHDhmAE0MJdFp8ckF/2SjdIkV49iWu6MPNfcF9qjgNA=="
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-network/-/jellyfish-network-0.24.0.tgz",
+      "integrity": "sha512-dqj1bVAK/TPi+No2Zolj6ElV8XPSo54gOt7b39FzRjc9WSjpn2nZrJAboGs6+9LFrpxPt5S+maoYQxuOcqbQFg=="
     },
     "@defichain/jellyfish-transaction": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction/-/jellyfish-transaction-0.22.0.tgz",
-      "integrity": "sha512-feNTv6EtW54IOStFYi3hGB0TcYzkt7zZ3V62soTUzeyojIHvTWCtUJnRT4oQcQiMQJkIRXlbVH6FbI5SFkaT8g==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction/-/jellyfish-transaction-0.24.0.tgz",
+      "integrity": "sha512-WdlT5gS7gpK+kCrlBSXvJGLYQBAwlWZPzr2byaHMU366wOCNnjMaTbG3I4h9VAi/dKLE6r9MNVYru3WqJYnkaQ==",
       "requires": {
-        "@defichain/jellyfish-crypto": "^0.22.0",
+        "@defichain/jellyfish-crypto": "^0.24.0",
         "smart-buffer": "^4.1.0"
       }
     },
     "@defichain/jellyfish-transaction-builder": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction-builder/-/jellyfish-transaction-builder-0.22.0.tgz",
-      "integrity": "sha512-mok4fAnoFW99q1molE3ss36aaHYOo2ugbLJDT5OzzoJMz0vLIgM7wxmEzIWu7hgR6KsL/AU9MkJFN11QpOcnHg==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction-builder/-/jellyfish-transaction-builder-0.24.0.tgz",
+      "integrity": "sha512-3iRlbAaqyfqaTmjLBXelTlFKMAhqioDF1j1OqQnXxLQrj83kMhI5jCSrhtcALjobQHqxCIP7uurfwpehRd18lA==",
       "requires": {
-        "@defichain/jellyfish-crypto": "^0.22.0",
-        "@defichain/jellyfish-transaction": "^0.22.0",
-        "@defichain/jellyfish-transaction-signature": "^0.22.0"
+        "@defichain/jellyfish-crypto": "^0.24.0",
+        "@defichain/jellyfish-transaction": "^0.24.0",
+        "@defichain/jellyfish-transaction-signature": "^0.24.0"
       }
     },
     "@defichain/jellyfish-transaction-signature": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction-signature/-/jellyfish-transaction-signature-0.22.0.tgz",
-      "integrity": "sha512-+ilAcorkCCVpJ+aeN6bJ+Eve2c6A6TisJkC+RZdGYo/gGjtGVSInaZ0qwJh01Cx/ce06XRqkL5b+1WQTjajnCQ==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction-signature/-/jellyfish-transaction-signature-0.24.0.tgz",
+      "integrity": "sha512-uMHm7OPX0qDtiUWbwC16+7V3Jgg0rZeZxnxRpdZ7qh/lWhaxpIwUIOUhwBv0mCNi4LOZFDhDvpvL91SqaYs9+w==",
       "requires": {
-        "@defichain/jellyfish-crypto": "^0.22.0",
-        "@defichain/jellyfish-transaction": "^0.22.0",
+        "@defichain/jellyfish-crypto": "^0.24.0",
+        "@defichain/jellyfish-transaction": "^0.24.0",
         "smart-buffer": "^4.1.0"
       }
     },
     "@defichain/jellyfish-wallet": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-wallet/-/jellyfish-wallet-0.22.0.tgz",
-      "integrity": "sha512-3BGgmVDBo4ZKUgGYX8P+F9c9DTxAS1CVzEgL/mLI816Nas3pkyBEL4nO764bu1+lrHEqGVi58BVF/7mQw4Z1ig==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-wallet/-/jellyfish-wallet-0.24.0.tgz",
+      "integrity": "sha512-64YL/jrDjIoy/N9qvuVBt4UREoeWr+uzW8IPJfCDNvCHR90sm+xzKJiFjoW9qrSB8pXh06SWluuFnXFjNV0I+g==",
       "requires": {
-        "@defichain/jellyfish-address": "^0.22.0",
-        "@defichain/jellyfish-crypto": "^0.22.0",
-        "@defichain/jellyfish-network": "^0.22.0",
-        "@defichain/jellyfish-transaction": "^0.22.0"
+        "@defichain/jellyfish-address": "^0.24.0",
+        "@defichain/jellyfish-crypto": "^0.24.0",
+        "@defichain/jellyfish-network": "^0.24.0",
+        "@defichain/jellyfish-transaction": "^0.24.0"
       }
     },
     "@defichain/testcontainers": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@defichain/testcontainers/-/testcontainers-0.22.0.tgz",
-      "integrity": "sha512-uVb5SSFHo0IXeiRI/SiwJyGb6gMd0O7iu5FMBEJiqSYxbclUBBtBcQgCjvl1SAPYLVSCiNXnur+O/mOWnk7KAQ==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@defichain/testcontainers/-/testcontainers-0.24.0.tgz",
+      "integrity": "sha512-rg7P7/gOnXe1j636AO0pyCv9XYYY478mNW8jbllZMuW26ZbHbiwImIVx1Us5WFaqtjzryAATnV8RD4bWOabYMA==",
       "dev": true,
       "requires": {
         "dockerode": "^3.3.0",
@@ -19034,21 +19034,21 @@
       }
     },
     "@defichain/testing": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@defichain/testing/-/testing-0.22.0.tgz",
-      "integrity": "sha512-mMn/eT208OFp0VwEpqEpAGunHv6A0DF4mutELiboOQPgil5ifQFtt36KJBq194heOfZWwvCU9hWkpIRDmLp6Ew==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@defichain/testing/-/testing-0.24.0.tgz",
+      "integrity": "sha512-zw37Pr+mUv1mTaQYWogQYgUF01sv48dvexw885dRzCapvaChc8a9aRRFNvw7/MuydRExKuWrAWJ2hZIj7atONw==",
       "dev": true,
       "requires": {
-        "@defichain/jellyfish-api-core": "^0.22.0",
-        "@defichain/jellyfish-crypto": "^0.22.0",
-        "@defichain/jellyfish-network": "^0.22.0",
-        "@defichain/testcontainers": "^0.22.0"
+        "@defichain/jellyfish-api-core": "^0.24.0",
+        "@defichain/jellyfish-crypto": "^0.24.0",
+        "@defichain/jellyfish-network": "^0.24.0",
+        "@defichain/testcontainers": "^0.24.0"
       }
     },
     "@defichain/whale-api-client": {
       "version": "file:packages/whale-api-client",
       "requires": {
-        "@defichain/jellyfish-api-core": ">=0.22.0",
+        "@defichain/jellyfish-api-core": ">=0.24.0",
         "abort-controller": "^3.0.0",
         "cross-fetch": "^3.1.2",
         "url-search-params-polyfill": "8.1.1"
@@ -19057,8 +19057,8 @@
     "@defichain/whale-api-wallet": {
       "version": "file:packages/whale-api-wallet",
       "requires": {
-        "@defichain/jellyfish-transaction-builder": ">=0.22.0",
-        "@defichain/jellyfish-wallet": ">=0.22.0",
+        "@defichain/jellyfish-transaction-builder": ">=0.24.0",
+        "@defichain/jellyfish-wallet": ">=0.24.0",
         "@defichain/whale-api-client": "0.0.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
     "packages:publish:latest": "lerna exec -- npm publish --tag latest --access public"
   },
   "dependencies": {
-    "@defichain/jellyfish-address": ">=0.22.0",
-    "@defichain/jellyfish-api-core": ">=0.22.0",
-    "@defichain/jellyfish-api-jsonrpc": ">=0.22.0",
-    "@defichain/jellyfish-json": ">=0.22.0",
-    "@defichain/jellyfish-network": ">=0.22.0",
-    "@defichain/jellyfish-transaction": ">=0.22.0",
+    "@defichain/jellyfish-address": ">=0.24.0",
+    "@defichain/jellyfish-api-core": ">=0.24.0",
+    "@defichain/jellyfish-api-jsonrpc": ">=0.24.0",
+    "@defichain/jellyfish-json": ">=0.24.0",
+    "@defichain/jellyfish-network": ">=0.24.0",
+    "@defichain/jellyfish-transaction": ">=0.24.0",
     "@nestjs/common": "^7.6.15",
     "@nestjs/config": "^0.6.3",
     "@nestjs/core": "^7.6.15",
@@ -51,9 +51,9 @@
     "subleveldown": "^5.0.1"
   },
   "devDependencies": {
-    "@defichain/jellyfish-crypto": ">=0.22.0",
-    "@defichain/testcontainers": ">=0.22.0",
-    "@defichain/testing": ">=0.22.0",
+    "@defichain/jellyfish-crypto": ">=0.24.0",
+    "@defichain/testcontainers": ">=0.24.0",
+    "@defichain/testing": ">=0.24.0",
     "@nestjs/cli": "^7.6.0",
     "@nestjs/schematics": "^7.3.0",
     "@nestjs/testing": "^7.6.15",

--- a/packages/whale-api-client/package.json
+++ b/packages/whale-api-client/package.json
@@ -40,7 +40,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@defichain/jellyfish-api-core": ">=0.22.0",
+    "@defichain/jellyfish-api-core": ">=0.24.0",
     "cross-fetch": "^3.1.2",
     "abort-controller": "^3.0.0",
     "url-search-params-polyfill": "8.1.1"

--- a/packages/whale-api-wallet/package.json
+++ b/packages/whale-api-wallet/package.json
@@ -40,8 +40,8 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@defichain/jellyfish-wallet": ">=0.22.0",
-    "@defichain/jellyfish-transaction-builder": ">=0.22.0",
+    "@defichain/jellyfish-wallet": ">=0.24.0",
+    "@defichain/jellyfish-transaction-builder": ">=0.24.0",
     "@defichain/whale-api-client": "0.0.0"
   }
 }

--- a/packages/whale-api-wallet/src/wallet.ts
+++ b/packages/whale-api-wallet/src/wallet.ts
@@ -1,4 +1,4 @@
-import { WalletAccount, WalletAccountProvider, WalletHdNode } from '@defichain/jellyfish-wallet'
+import { WalletAccount, WalletAccountProvider, WalletEllipticPair } from '@defichain/jellyfish-wallet'
 import { WhaleApiClient } from '@defichain/whale-api-client'
 import { Network } from '@defichain/jellyfish-network'
 import { P2WPKHTransactionBuilder } from '@defichain/jellyfish-transaction-builder/dist'
@@ -9,8 +9,13 @@ export class WhaleWalletAccount extends WalletAccount {
   protected readonly feeRateProvider: WhaleFeeRateProvider
   protected readonly prevoutProvider: WhalePrevoutProvider
 
-  constructor (public readonly client: WhaleApiClient, hdNode: WalletHdNode, network: Network, prevoutSize: number = 50) {
-    super(hdNode, network)
+  constructor (
+    public readonly client: WhaleApiClient,
+    walletEllipticPair: WalletEllipticPair,
+    network: Network,
+    prevoutSize: number = 50
+  ) {
+    super(walletEllipticPair, network)
     this.feeRateProvider = new WhaleFeeRateProvider(client)
     this.prevoutProvider = new WhalePrevoutProvider(this, prevoutSize)
   }
@@ -35,7 +40,7 @@ export class WhaleWalletAccountProvider implements WalletAccountProvider<WhaleWa
   ) {
   }
 
-  provide (hdNode: WalletHdNode): WhaleWalletAccount {
-    return new WhaleWalletAccount(this.client, hdNode, this.network)
+  provide (walletEllipticPair: WalletEllipticPair): WhaleWalletAccount {
+    return new WhaleWalletAccount(this.client, walletEllipticPair, this.network)
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind dependencies

#### What this PR does / why we need it:

1. `WalletEllipticPair` should be used now as `WalletHdNode` is not required for non-hd wallets.
2. included library consumer into whale packages CODEOWNERS 
