### PR TITLE
Included `time` and `medianTime` to endpoints: `address/*` & `blocks/transaction`

### DIFF
--- a/packages/whale-api-client/__tests__/api/address.test.ts
+++ b/packages/whale-api-client/__tests__/api/address.test.ts
@@ -106,7 +106,9 @@ it('should getAggregation', async () => {
     },
     block: {
       hash: expect.stringMatching(/[0-f]{64}/),
-      height: expect.any(Number)
+      height: expect.any(Number),
+      time: expect.any(Number),
+      medianTime: expect.any(Number)
     },
     hid: expect.stringMatching(/[0-f]{64}/),
     id: expect.stringMatching(/[0-f]{72}/),
@@ -195,7 +197,9 @@ describe('transactions', () => {
     expect(transactions[2]).toStrictEqual({
       block: {
         hash: expect.stringMatching(/[0-f]{64}/),
-        height: expect.any(Number)
+        height: expect.any(Number),
+        time: expect.any(Number),
+        medianTime: expect.any(Number)
       },
       hid: expect.stringMatching(/[0-f]{64}/),
       id: expect.stringMatching(/[0-f]{72}/),
@@ -240,7 +244,9 @@ describe('transactions', () => {
     expect(unspent[0]).toStrictEqual({
       block: {
         hash: expect.stringMatching(/[0-f]{64}/),
-        height: expect.any(Number)
+        height: expect.any(Number),
+        time: expect.any(Number),
+        medianTime: expect.any(Number)
       },
       hid: expect.stringMatching(/[0-f]{64}/),
       id: expect.stringMatching(/[0-f]{72}/),

--- a/packages/whale-api-client/__tests__/api/blocks.test.ts
+++ b/packages/whale-api-client/__tests__/api/blocks.test.ts
@@ -120,7 +120,9 @@ describe('getTransactions', () => {
     id: expect.stringMatching(/[0-f]{64}/),
     block: {
       hash: expect.stringMatching(/[0-f]{64}/),
-      height: expect.any(Number)
+      height: expect.any(Number),
+      time: expect.any(Number),
+      medianTime: expect.any(Number)
     },
     txid: expect.stringMatching(/[0-f]{64}/),
     hash: expect.stringMatching(/[0-f]{64}/),

--- a/packages/whale-api-client/__tests__/api/transaction.test.ts
+++ b/packages/whale-api-client/__tests__/api/transaction.test.ts
@@ -272,7 +272,9 @@ describe('transaction', () => {
         id: txid,
         block: {
           hash: expect.any(String),
-          height: expect.any(Number)
+          height: expect.any(Number),
+          time: expect.any(Number),
+          medianTime: expect.any(Number)
         },
         txid,
         hash: txid,

--- a/packages/whale-api-client/src/api/address.ts
+++ b/packages/whale-api-client/src/api/address.ts
@@ -86,6 +86,8 @@ export interface AddressAggregation {
   block: {
     hash: string
     height: number
+    time: number
+    medianTime: number
   }
 
   script: {
@@ -117,6 +119,8 @@ export interface AddressActivity {
   block: {
     hash: string
     height: number
+    time: number
+    medianTime: number
   }
 
   script: {
@@ -146,6 +150,8 @@ export interface AddressUnspent {
   block: {
     hash: string
     height: number
+    time: number
+    medianTime: number
   }
 
   script: {

--- a/packages/whale-api-client/src/api/transactions.ts
+++ b/packages/whale-api-client/src/api/transactions.ts
@@ -53,6 +53,8 @@ export interface Transaction {
   block: {
     hash: string
     height: number
+    time: number
+    medianTime: number
   }
   txid: string
   hash: string

--- a/src/module.api/address.controller.e2e.ts
+++ b/src/module.api/address.controller.e2e.ts
@@ -114,7 +114,9 @@ describe('getAggregation', () => {
       },
       block: {
         hash: expect.stringMatching(/[0-f]{64}/),
-        height: expect.any(Number)
+        height: expect.any(Number),
+        time: expect.any(Number),
+        medianTime: expect.any(Number)
       },
       hid: expect.stringMatching(/[0-f]{64}/),
       id: expect.stringMatching(/[0-f]{72}/),
@@ -193,7 +195,9 @@ describe('listTransactions', () => {
     expect(response.data[5]).toStrictEqual({
       block: {
         hash: expect.stringMatching(/[0-f]{64}/),
-        height: expect.any(Number)
+        height: expect.any(Number),
+        time: expect.any(Number),
+        medianTime: expect.any(Number)
       },
       hid: expect.stringMatching(/[0-f]{64}/),
       id: expect.stringMatching(/[0-f]{72}/),
@@ -261,7 +265,9 @@ describe('listTransactions', () => {
     expect(response.data[1]).toStrictEqual({
       block: {
         hash: expect.stringMatching(/[0-f]{64}/),
-        height: expect.any(Number)
+        height: expect.any(Number),
+        time: expect.any(Number),
+        medianTime: expect.any(Number)
       },
       hid: expect.stringMatching(/[0-f]{64}/),
       id: expect.stringMatching(/[0-f]{72}/),
@@ -350,7 +356,9 @@ describe('listTransactionsUnspent', () => {
     expect(response.data[3]).toStrictEqual({
       block: {
         hash: expect.stringMatching(/[0-f]{64}/),
-        height: expect.any(Number)
+        height: expect.any(Number),
+        time: expect.any(Number),
+        medianTime: expect.any(Number)
       },
       hid: expect.stringMatching(/[0-f]{64}/),
       id: expect.stringMatching(/[0-f]{72}/),
@@ -398,7 +406,9 @@ describe('listTransactionsUnspent', () => {
     expect(response.data[1]).toStrictEqual({
       block: {
         hash: expect.stringMatching(/[0-f]{64}/),
-        height: expect.any(Number)
+        height: expect.any(Number),
+        time: expect.any(Number),
+        medianTime: expect.any(Number)
       },
       hid: expect.stringMatching(/[0-f]{64}/),
       id: expect.stringMatching(/[0-f]{72}/),

--- a/src/module.api/transaction.controller.e2e.ts
+++ b/src/module.api/transaction.controller.e2e.ts
@@ -209,7 +209,9 @@ describe('transactions', () => {
         id: txid,
         block: {
           hash: expect.any(String),
-          height: expect.any(Number)
+          height: expect.any(Number),
+          time: expect.any(Number),
+          medianTime: expect.any(Number)
         },
         txid,
         hash: expect.any(String),

--- a/src/module.indexer/model/script.activity.ts
+++ b/src/module.indexer/model/script.activity.ts
@@ -66,7 +66,9 @@ export class ScriptActivityIndexer extends Indexer {
       txid: txn.txid,
       block: {
         hash: block.hash,
-        height: block.height
+        height: block.height,
+        time: block.time,
+        medianTime: block.mediantime
       },
       script: {
         type: vout.script.type,
@@ -90,7 +92,9 @@ export class ScriptActivityIndexer extends Indexer {
       txid: txn.txid,
       block: {
         hash: block.hash,
-        height: block.height
+        height: block.height,
+        time: block.time,
+        medianTime: block.mediantime
       },
       script: {
         type: vout.scriptPubKey.type,

--- a/src/module.indexer/model/script.aggregation.ts
+++ b/src/module.indexer/model/script.aggregation.ts
@@ -110,7 +110,9 @@ export class ScriptAggregationIndexer extends Indexer {
       hid: hid,
       block: {
         hash: block.hash,
-        height: block.height
+        height: block.height,
+        time: block.time,
+        medianTime: block.mediantime
       },
       script: {
         type: type,

--- a/src/module.indexer/model/script.unspent.ts
+++ b/src/module.indexer/model/script.unspent.ts
@@ -62,7 +62,9 @@ export class ScriptUnspentIndexer extends Indexer {
       sort: HexEncoder.encodeHeight(block.height) + txn.txid + HexEncoder.encodeVoutIndex(vout.n),
       block: {
         hash: block.hash,
-        height: block.height
+        height: block.height,
+        time: block.time,
+        medianTime: block.mediantime
       },
       script: {
         type: vout.scriptPubKey.type,
@@ -84,7 +86,9 @@ export class ScriptUnspentIndexer extends Indexer {
       sort: HexEncoder.encodeHeight(txn.block.height) + txn.txid + HexEncoder.encodeVoutIndex(vout.n),
       block: {
         hash: txn.block.hash,
-        height: txn.block.height
+        height: txn.block.height,
+        time: txn.block.time,
+        medianTime: txn.block.medianTime
       },
       script: {
         type: vout.script.type,

--- a/src/module.indexer/model/transaction.ts
+++ b/src/module.indexer/model/transaction.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common'
-import { Indexer, defid, RawBlock } from '@src/module.indexer/model/_abstract'
+import { defid, Indexer, RawBlock } from '@src/module.indexer/model/_abstract'
 import { Transaction, TransactionMapper } from '@src/module.model/transaction'
 
 @Injectable()
@@ -25,7 +25,9 @@ export class TransactionIndexer extends Indexer {
       id: txn.txid,
       block: {
         hash: block.hash,
-        height: block.height
+        height: block.height,
+        time: block.time,
+        medianTime: block.mediantime
       },
       txid: txn.txid,
       hash: txn.hash,

--- a/src/module.model/script.activity.spec.ts
+++ b/src/module.model/script.activity.spec.ts
@@ -27,7 +27,7 @@ beforeEach(async () => {
     await mapper.put({
       id: HexEncoder.encodeHeight(height) + ScriptActivityMapper.typeAsHex(type) + txid + HexEncoder.encodeVoutIndex(n),
       hid: HexEncoder.asSHA256(hex),
-      block: { hash: '', height: height },
+      block: { hash: '', height: height, time: 0, medianTime: 0 },
       script: { hex: hex, type: '' },
       txid: txid,
       type: type,

--- a/src/module.model/script.activity.ts
+++ b/src/module.model/script.activity.ts
@@ -73,6 +73,8 @@ export interface ScriptActivity extends Model {
   block: {
     hash: string
     height: number
+    time: number
+    medianTime: number
   }
 
   script: {

--- a/src/module.model/script.aggregation.ts
+++ b/src/module.model/script.aggregation.ts
@@ -97,6 +97,8 @@ export interface ScriptAggregation extends Model {
   block: {
     hash: string // --------------| block hash of this script aggregation
     height: number // ------------| block height of this script aggregation
+    time: number
+    medianTime: number
   }
 
   script: {

--- a/src/module.model/script.unspent.ts
+++ b/src/module.model/script.unspent.ts
@@ -50,6 +50,8 @@ export interface ScriptUnspent extends Model {
   block: {
     hash: string // ------------| block hash of this script unspent
     height: number // ----------| block height of this script unspent
+    time: number
+    medianTime: number
   }
 
   script: {

--- a/src/module.model/transaction.ts
+++ b/src/module.model/transaction.ts
@@ -55,6 +55,8 @@ export interface Transaction extends Model {
   block: {
     hash: string
     height: number
+    time: number
+    medianTime: number
   }
 
   txid: string


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:

Add `time` and `medianTime` to all indexed models with `block: {}`.

Fixes #175 
Fixes #178


