### PR TITLE
Added SemaphoreCache to limit concurrency for certain expensive operations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@nestjs/platform-fastify": "^8.0.4",
         "@nestjs/schedule": "^1.0.0",
         "@nestjs/terminus": "^7.2.0",
+        "async-mutex": "^0.3.1",
         "bignumber.js": "^9.0.1",
         "cache-manager": "^3.4.3",
         "class-transformer": "^0.4.0",
@@ -4442,6 +4443,19 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
       "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
+    },
+    "node_modules/async-mutex": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.1.tgz",
+      "integrity": "sha512-vRfQwcqBnJTLzVQo72Sf7KIUbcSUP5hNchx6udI1U6LuPQpfePgdjJzlCe76yFZ8pxlLjn9lwcl/Ya0TSOv0Tw==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/async-mutex/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -21991,6 +22005,21 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
       "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
+    },
+    "async-mutex": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.1.tgz",
+      "integrity": "sha512-vRfQwcqBnJTLzVQo72Sf7KIUbcSUP5hNchx6udI1U6LuPQpfePgdjJzlCe76yFZ8pxlLjn9lwcl/Ya0TSOv0Tw==",
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
     },
     "asynckit": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@nestjs/platform-fastify": "^8.0.4",
     "@nestjs/schedule": "^1.0.0",
     "@nestjs/terminus": "^7.2.0",
+    "async-mutex": "^0.3.1",
     "bignumber.js": "^9.0.1",
     "cache-manager": "^3.4.3",
     "class-transformer": "^0.4.0",

--- a/src/module.api/_module.ts
+++ b/src/module.api/_module.ts
@@ -17,6 +17,7 @@ import { ConfigService } from '@nestjs/config'
 import { NetworkName } from '@defichain/jellyfish-network'
 import { OraclesController } from '@src/module.api/oracles.controller'
 import { PricesController } from '@src/module.api/prices.controller'
+import { SemaphoreCache } from '@src/module.api/cache/semaphore.cache'
 
 /**
  * Exposed ApiModule for public interfacing
@@ -48,6 +49,7 @@ import { PricesController } from '@src/module.api/prices.controller'
       inject: [ConfigService]
     },
     DeFiDCache,
+    SemaphoreCache,
     PoolPairService
   ]
 })

--- a/src/module.api/cache/semaphore.cache.spec.ts
+++ b/src/module.api/cache/semaphore.cache.spec.ts
@@ -1,0 +1,50 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { CacheModule } from '@nestjs/common'
+import { SemaphoreCache } from '@src/module.api/cache/semaphore.cache'
+
+let testing: TestingModule
+let cache: SemaphoreCache
+
+beforeAll(async () => {
+  testing = await Test.createTestingModule({
+    imports: [CacheModule.register()],
+    providers: [SemaphoreCache]
+  }).compile()
+
+  cache = testing.get(SemaphoreCache)
+})
+
+it('should run twice with they same key, due to concurrency of 2', async () => {
+  let counter = 0
+  const fetch = async (): Promise<string> => await new Promise((resolve) => {
+    counter += 1
+    setTimeout(() => resolve('1'), 1000)
+  })
+
+  await Promise.all([
+    cache.get('collide-1', fetch),
+    cache.get('collide-1', fetch),
+    cache.get('collide-1', fetch),
+    cache.get('collide-1', fetch)
+  ])
+
+  expect(counter).toStrictEqual(2)
+})
+
+it('key should not collide', async () => {
+  let counter = 0
+  const fetch = async (): Promise<string> => await new Promise((resolve) => {
+    counter += 1
+    setTimeout(() => resolve('1'), 1000)
+  })
+
+  await Promise.all([
+    cache.get('not-collide-1', fetch),
+    cache.get('not-collide-2', fetch),
+    cache.get('not-collide-3', fetch),
+    cache.get('not-collide-4', fetch),
+    cache.get('not-collide-5', fetch)
+  ])
+
+  expect(counter).toStrictEqual(5)
+})

--- a/src/module.api/cache/semaphore.cache.ts
+++ b/src/module.api/cache/semaphore.cache.ts
@@ -17,6 +17,8 @@ export class SemaphoreCache {
   }
 
   /**
+   * Resolve from SemaphoreCache cache key via double-checked locking.
+   *
    * @param {string} key to use for semaphore cache
    * @param {(id: string) => Promise<T | undefined>} fetch if miss cache
    * @param {GlobalCache} options

--- a/src/module.api/cache/semaphore.cache.ts
+++ b/src/module.api/cache/semaphore.cache.ts
@@ -1,0 +1,46 @@
+import { Semaphore, SemaphoreInterface, withTimeout } from 'async-mutex'
+import { CacheOption, GlobalCache } from '@src/module.api/cache/global.cache'
+import { CACHE_MANAGER, Inject, Injectable } from '@nestjs/common'
+import { Cache } from 'cache-manager'
+
+@Injectable()
+export class SemaphoreCache {
+  static PREFIX = -1
+  static MAX_CONCURRENCY = 2
+  static TIMEOUT = 45000
+
+  protected readonly cache: GlobalCache
+  protected readonly semaphores: Record<string, SemaphoreInterface> = {}
+
+  constructor (@Inject(CACHE_MANAGER) cacheManager: Cache) {
+    this.cache = new GlobalCache(cacheManager)
+  }
+
+  /**
+   * @param {string} key to use for semaphore cache
+   * @param {(id: string) => Promise<T | undefined>} fetch if miss cache
+   * @param {GlobalCache} options
+   */
+  async get<T> (key: string, fetch: () => Promise<T | undefined>, options: CacheOption = {}): Promise<T | undefined> {
+    return await this.cache.get(SemaphoreCache.PREFIX, key, async () => {
+      const semaphore = this.acquireSemaphore(key)
+      return await semaphore.runExclusive(async () => {
+        return await this.cache.get(SemaphoreCache.PREFIX, key, async () => {
+          return await fetch()
+        }, options)
+      })
+    }, options)
+  }
+
+  /**
+   * @param {string} key to lock cache concurrency
+   */
+  private acquireSemaphore (key: string): SemaphoreInterface {
+    const semaphore = this.semaphores[key]
+    if (semaphore === undefined) {
+      this.semaphores[key] = withTimeout(new Semaphore(SemaphoreCache.MAX_CONCURRENCY), SemaphoreCache.TIMEOUT)
+    }
+
+    return this.semaphores[key]
+  }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

Certain operations such as #136 and #246 are expensive to compute, this will limit the concurrency of that critical zone to just 2 with double-checked locking.

This is a pre-req for #246.