### PR TITLE
Refactor `TVL` calculation to use `SemaphoreCache`

### DIFF
--- a/packages/whale-api-client/__tests__/api/poolpairs.test.ts
+++ b/packages/whale-api-client/__tests__/api/poolpairs.test.ts
@@ -3,9 +3,7 @@ import { StubWhaleApiClient } from '../stub.client'
 import { StubService } from '../stub.service'
 import { ApiPagedResponse, WhaleApiClient, WhaleApiException } from '../../src'
 import { addPoolLiquidity, createPoolPair, createToken, getNewAddress, mintTokens } from '@defichain/testing'
-import { PoolPairService } from '@src/module.api/poolpair.service'
 import { PoolPairData } from '../../src/api/poolpairs'
-import waitForExpect from 'wait-for-expect'
 
 let container: MasterNodeRegTestContainer
 let service: StubService
@@ -17,16 +15,10 @@ beforeAll(async () => {
   client = new StubWhaleApiClient(service)
 
   await container.start()
-  await container.waitForReady()
   await container.waitForWalletCoinbaseMaturity()
   await service.start()
 
   await setup()
-
-  await waitForExpect(() => {
-    // @ts-expect-error
-    expect(service.app?.get(PoolPairService).USDT_PER_DFI).toBeDefined()
-  }, 61000) // 60 seconds interval
 })
 
 afterAll(async () => {

--- a/src/module.api/poolpair.controller.e2e.ts
+++ b/src/module.api/poolpair.controller.e2e.ts
@@ -4,7 +4,6 @@ import { NestFastifyApplication } from '@nestjs/platform-fastify'
 import { createTestingApp, stopTestingApp, waitForIndexedHeight } from '@src/e2e.module'
 import { addPoolLiquidity, createPoolPair, createToken, getNewAddress, mintTokens } from '@defichain/testing'
 import { NotFoundException } from '@nestjs/common'
-import { PoolPairService } from '@src/module.api/poolpair.service'
 
 const container = new MasterNodeRegTestContainer()
 let app: NestFastifyApplication
@@ -12,7 +11,6 @@ let controller: PoolPairController
 
 beforeAll(async () => {
   await container.start()
-  await container.waitForReady()
   await container.waitForWalletCoinbaseMaturity()
   await container.waitForWalletBalanceGTE(100)
 
@@ -22,7 +20,6 @@ beforeAll(async () => {
   await waitForIndexedHeight(app, 100)
 
   await setup()
-  await app.get(PoolPairService).syncDfiUsdPair()
 })
 
 afterAll(async () => {

--- a/src/module.api/poolpair.controller.spec.ts
+++ b/src/module.api/poolpair.controller.spec.ts
@@ -7,6 +7,7 @@ import { addPoolLiquidity, createPoolPair, createToken, getNewAddress, mintToken
 import { CacheModule, NotFoundException } from '@nestjs/common'
 import { DeFiDCache } from './cache/defid.cache'
 import { ConfigService } from '@nestjs/config'
+import { SemaphoreCache } from '@src/module.api/cache/semaphore.cache'
 
 const container = new MasterNodeRegTestContainer()
 let controller: PoolPairController
@@ -24,6 +25,7 @@ beforeAll(async () => {
     providers: [
       { provide: JsonRpcClient, useValue: client },
       DeFiDCache,
+      SemaphoreCache,
       PoolPairService,
       ConfigService
     ]

--- a/src/module.api/poolpair.controller.spec.ts
+++ b/src/module.api/poolpair.controller.spec.ts
@@ -13,7 +13,6 @@ let controller: PoolPairController
 
 beforeAll(async () => {
   await container.start()
-  await container.waitForReady()
   await container.waitForWalletCoinbaseMaturity()
   const client = new JsonRpcClient(await container.getCachedRpcUrl())
 
@@ -33,7 +32,6 @@ beforeAll(async () => {
   controller = app.get(PoolPairController)
 
   await setup()
-  await app.get(PoolPairService).syncDfiUsdPair()
 })
 
 afterAll(async () => {

--- a/src/module.api/poolpair.controller.ts
+++ b/src/module.api/poolpair.controller.ts
@@ -33,10 +33,12 @@ export class PoolPairController {
       limit: query.size
     }, true)
 
-    const items = Object.entries(result).map(([id, info]) => {
-      const totalLiquidityUsd = this.poolPairService.getTotalLiquidityUsd(info)
-      return mapPoolPair(id, info, totalLiquidityUsd)
-    })
+    const items: PoolPairData[] = []
+    for (const [id, info] of Object.entries(result)) {
+      const totalLiquidityUsd = await this.poolPairService.getTotalLiquidityUsd(info)
+      items.push(mapPoolPair(id, info, totalLiquidityUsd))
+    }
+
     return ApiPagedResponse.of(items, query.size, item => {
       return item.id
     })
@@ -53,7 +55,7 @@ export class PoolPairController {
       throw new NotFoundException('Unable to find poolpair')
     }
 
-    const totalLiquidityUsd = this.poolPairService.getTotalLiquidityUsd(info)
+    const totalLiquidityUsd = await this.poolPairService.getTotalLiquidityUsd(info)
     return mapPoolPair(String(id), info, totalLiquidityUsd)
   }
 }

--- a/src/module.api/poolpair.service.ts
+++ b/src/module.api/poolpair.service.ts
@@ -73,7 +73,7 @@ export class PoolPairService {
         }
       }
     }, {
-      ttl: 600
+      ttl: 180
     })
   }
 }

--- a/src/module.api/poolpair.service.ts
+++ b/src/module.api/poolpair.service.ts
@@ -1,45 +1,17 @@
-import { Injectable, Logger } from '@nestjs/common'
+import { Injectable } from '@nestjs/common'
 import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
 import BigNumber from 'bignumber.js'
 import { PoolPairInfo } from '@defichain/jellyfish-api-core/dist/category/poolpair'
-import { Interval } from '@nestjs/schedule'
+import { SemaphoreCache } from '@src/module.api/cache/semaphore.cache'
 
 @Injectable()
 export class PoolPairService {
-  private readonly logger = new Logger(PoolPairService.name)
-  private USDT_PER_DFI: BigNumber | undefined
-  private syncing: boolean = false
+  private readonly USDT_PER_DFI: BigNumber | undefined
 
   constructor (
-    protected readonly rpcClient: JsonRpcClient
+    protected readonly rpcClient: JsonRpcClient,
+    protected readonly cache: SemaphoreCache
   ) {
-  }
-
-  @Interval(60000)
-  private async sync (): Promise<void> {
-    if (this.syncing) return
-
-    try {
-      this.syncing = true
-      await this.syncDfiUsdPair()
-    } catch (err) {
-      this.logger.error('sync error', err)
-    } finally {
-      this.syncing = false
-    }
-  }
-
-  async syncDfiUsdPair (): Promise<void> {
-    const pair = await this.getPoolPair('DFI', 'USDT')
-    if (pair === undefined) {
-      return
-    }
-
-    if (pair.idTokenA === '0') {
-      this.USDT_PER_DFI = new BigNumber(pair['reserveB/reserveA'])
-    } else if (pair.idTokenB === '0') {
-      this.USDT_PER_DFI = new BigNumber(pair['reserveA/reserveB'])
-    }
   }
 
   /**
@@ -74,18 +46,34 @@ export class PoolPairService {
    * Currently implemented with fix pair derivation
    * Ideally should use vertex directed graph where we can always find total liquidity if it can be resolved.
    */
-  getTotalLiquidityUsd (info: PoolPairInfo): BigNumber | undefined {
-    if (this.USDT_PER_DFI === undefined) {
+  async getTotalLiquidityUsd (info: PoolPairInfo): Promise<BigNumber | undefined> {
+    const USDT_PER_DFI = await this.getUSDT_PER_DFI()
+    if (USDT_PER_DFI === undefined) {
       return
     }
 
     const [a, b] = info.symbol.split('-')
     if (a === 'DFI') {
-      return info.reserveA.multipliedBy(2).multipliedBy(this.USDT_PER_DFI)
+      return info.reserveA.multipliedBy(2).multipliedBy(USDT_PER_DFI)
     }
 
     if (b === 'DFI') {
-      return info.reserveB.multipliedBy(2).multipliedBy(this.USDT_PER_DFI)
+      return info.reserveB.multipliedBy(2).multipliedBy(USDT_PER_DFI)
     }
+  }
+
+  private async getUSDT_PER_DFI (): Promise<BigNumber | undefined> {
+    return await this.cache.get<BigNumber>('USDT_PER_DFI', async () => {
+      const pair = await this.getPoolPair('DFI', 'USDT')
+      if (pair !== undefined) {
+        if (pair.idTokenA === '0') {
+          return new BigNumber(pair['reserveB/reserveA'])
+        } else if (pair.idTokenB === '0') {
+          return new BigNumber(pair['reserveA/reserveB'])
+        }
+      }
+    }, {
+      ttl: 600
+    })
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind refactor

#### What this PR does / why we need it:

`@Interval(60000)` is not consistent leading to `undefined` if not loaded when Whale instance mark as healthy. Refactored TVL calculations to use `SemaphoreCache` for better reliability where calculation will be computed via typical cache hit/miss.