### PR TITLE
Add `/stats` endpoint

### DIFF
--- a/packages/whale-api-client/__tests__/api/stats.test.ts
+++ b/packages/whale-api-client/__tests__/api/stats.test.ts
@@ -2,7 +2,7 @@ import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { StubWhaleApiClient } from '../stub.client'
 import { StubService } from '../stub.service'
 import { WhaleApiClient } from '../../src'
-import { createPoolPair, createToken } from '@defichain/testing'
+import { addPoolLiquidity, createPoolPair, createToken, getNewAddress, mintTokens } from '@defichain/testing'
 
 let container: MasterNodeRegTestContainer
 let service: StubService
@@ -14,12 +14,43 @@ beforeAll(async () => {
   client = new StubWhaleApiClient(service)
 
   await container.start()
-  await container.waitForReady()
   await container.waitForWalletCoinbaseMaturity()
   await service.start()
-  await createToken(container, 'DBTC')
-  await createToken(container, 'DETH')
-  await createPoolPair(container, 'DBTC', 'DETH')
+
+  await createToken(container, 'A')
+  await mintTokens(container, 'A')
+  await createToken(container, 'B')
+  await mintTokens(container, 'B')
+
+  await createPoolPair(container, 'A', 'DFI')
+  await addPoolLiquidity(container, {
+    tokenA: 'A',
+    amountA: 100,
+    tokenB: 'DFI',
+    amountB: 200,
+    shareAddress: await getNewAddress(container)
+  })
+  await createPoolPair(container, 'B', 'DFI')
+  await addPoolLiquidity(container, {
+    tokenA: 'B',
+    amountA: 50,
+    tokenB: 'DFI',
+    amountB: 200,
+    shareAddress: await getNewAddress(container)
+  })
+  await createToken(container, 'USDT')
+  await createPoolPair(container, 'USDT', 'DFI')
+  await mintTokens(container, 'USDT')
+  await addPoolLiquidity(container, {
+    tokenA: 'USDT',
+    amountA: 1000,
+    tokenB: 'DFI',
+    amountB: 431.51288,
+    shareAddress: await getNewAddress(container)
+  })
+  const height = await container.getBlockCount()
+  await container.generate(1)
+  await service.waitForIndexedHeight(height)
 })
 
 afterAll(async () => {
@@ -33,6 +64,11 @@ afterAll(async () => {
 describe('stats', () => {
   it('should get', async () => {
     const data = await client.stats.get()
-    // TODO(fuxingloh):
+    expect(data).toStrictEqual({
+      count: { blocks: 117, prices: 0, tokens: 7 },
+      burned: { address: 0, emission: 7014.88, fee: 3, total: 7017.88 },
+      tvl: { dex: 3853.9423279032194, total: 3853.9423279032194 },
+      price: { usdt: 2.31742792 }
+    })
   })
 })

--- a/packages/whale-api-client/__tests__/api/stats.test.ts
+++ b/packages/whale-api-client/__tests__/api/stats.test.ts
@@ -1,0 +1,38 @@
+import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
+import { StubWhaleApiClient } from '../stub.client'
+import { StubService } from '../stub.service'
+import { WhaleApiClient } from '../../src'
+import { createPoolPair, createToken } from '@defichain/testing'
+
+let container: MasterNodeRegTestContainer
+let service: StubService
+let client: WhaleApiClient
+
+beforeAll(async () => {
+  container = new MasterNodeRegTestContainer()
+  service = new StubService(container)
+  client = new StubWhaleApiClient(service)
+
+  await container.start()
+  await container.waitForReady()
+  await container.waitForWalletCoinbaseMaturity()
+  await service.start()
+  await createToken(container, 'DBTC')
+  await createToken(container, 'DETH')
+  await createPoolPair(container, 'DBTC', 'DETH')
+})
+
+afterAll(async () => {
+  try {
+    await service.stop()
+  } finally {
+    await container.stop()
+  }
+})
+
+describe('stats', () => {
+  it('should get', async () => {
+    const data = await client.stats.get()
+    // TODO(fuxingloh):
+  })
+})

--- a/packages/whale-api-client/src/api/stats.ts
+++ b/packages/whale-api-client/src/api/stats.ts
@@ -1,0 +1,19 @@
+import { WhaleApiClient } from '../whale.api.client'
+
+export class Stats {
+  constructor (private readonly client: WhaleApiClient) {
+  }
+
+  /**
+   * Get stats of DeFi Blockchain
+   *
+   * @return {Promise<StatsData>}
+   */
+  async get (): Promise<StatsData> {
+    return await this.client.requestData('GET', `stats`)
+  }
+}
+
+export interface StatsData {
+
+}

--- a/packages/whale-api-client/src/api/stats.ts
+++ b/packages/whale-api-client/src/api/stats.ts
@@ -10,21 +10,24 @@ export class Stats {
    * @return {Promise<StatsData>}
    */
   async get (): Promise<StatsData> {
-    return await this.client.requestData('GET', `stats`)
+    return await this.client.requestData('GET', 'stats')
   }
 }
 
+/**
+ * Stats data, doesn't use BigNumber is precision is not expected.
+ */
 export interface StatsData {
   count: {
     blocks: number
     tokens: number
     prices: number
-    masternodes: number
+    // TODO(fuxingloh): `masternodes: number` must be indexed via aggregator
   }
   tvl: {
     total: number
     dex: number
-    masternode: number
+    // TODO(fuxingloh): `masternode: number` must be indexed via aggregator
   }
   burned: {
     total: number

--- a/packages/whale-api-client/src/api/stats.ts
+++ b/packages/whale-api-client/src/api/stats.ts
@@ -15,5 +15,24 @@ export class Stats {
 }
 
 export interface StatsData {
-
+  count: {
+    blocks: number
+    tokens: number
+    prices: number
+    masternodes: number
+  }
+  tvl: {
+    total: number
+    dex: number
+    masternode: number
+  }
+  burned: {
+    total: number
+    fee: number
+    emission: number
+    address: number
+  }
+  price: {
+    usdt: number
+  }
 }

--- a/packages/whale-api-client/src/index.ts
+++ b/packages/whale-api-client/src/index.ts
@@ -9,6 +9,7 @@ export * as masternodes from './api/masternodes'
 export * as blocks from './api/blocks'
 export * as oracles from './api/oracles'
 export * as prices from './api/prices'
+export * as stats from './api/stats'
 
 export * from './whale.api.client'
 export * from './whale.api.response'

--- a/packages/whale-api-client/src/whale.api.client.ts
+++ b/packages/whale-api-client/src/whale.api.client.ts
@@ -13,7 +13,7 @@ import { Masternodes } from './api/masternodes'
 import { Blocks } from './api/blocks'
 import { Oracles } from './api/oracles'
 import { Prices } from './api/prices'
-import { Stats } from "./api/stats";
+import { Stats } from './api/stats'
 
 /**
  * WhaleApiClient Options

--- a/packages/whale-api-client/src/whale.api.client.ts
+++ b/packages/whale-api-client/src/whale.api.client.ts
@@ -13,6 +13,7 @@ import { Masternodes } from './api/masternodes'
 import { Blocks } from './api/blocks'
 import { Oracles } from './api/oracles'
 import { Prices } from './api/prices'
+import { Stats } from "./api/stats";
 
 /**
  * WhaleApiClient Options
@@ -68,6 +69,7 @@ export class WhaleApiClient {
   public readonly blocks = new Blocks(this)
   public readonly oracles = new Oracles(this)
   public readonly prices = new Prices(this)
+  public readonly stats = new Stats(this)
 
   constructor (
     protected readonly options: WhaleApiClientOptions

--- a/src/module.api/_module.ts
+++ b/src/module.api/_module.ts
@@ -18,7 +18,7 @@ import { ConfigService } from '@nestjs/config'
 import { NetworkName } from '@defichain/jellyfish-network'
 import { OraclesController } from '@src/module.api/oracles.controller'
 import { PricesController } from '@src/module.api/prices.controller'
-import { StatsController } from "@src/module.api/stats.controller";
+import { StatsController } from '@src/module.api/stats.controller'
 
 /**
  * Exposed ApiModule for public interfacing

--- a/src/module.api/_module.ts
+++ b/src/module.api/_module.ts
@@ -8,6 +8,7 @@ import { AddressController } from '@src/module.api/address.controller'
 import { PoolPairController } from '@src/module.api/poolpair.controller'
 import { PoolPairService } from '@src/module.api/poolpair.service'
 import { DeFiDCache } from '@src/module.api/cache/defid.cache'
+import { SemaphoreCache } from '@src/module.api/cache/semaphore.cache'
 import { ExceptionInterceptor } from '@src/module.api/interceptors/exception.interceptor'
 import { ResponseInterceptor } from '@src/module.api/interceptors/response.interceptor'
 import { TokensController } from '@src/module.api/token.controller'
@@ -17,7 +18,7 @@ import { ConfigService } from '@nestjs/config'
 import { NetworkName } from '@defichain/jellyfish-network'
 import { OraclesController } from '@src/module.api/oracles.controller'
 import { PricesController } from '@src/module.api/prices.controller'
-import { SemaphoreCache } from '@src/module.api/cache/semaphore.cache'
+import { StatsController } from "@src/module.api/stats.controller";
 
 /**
  * Exposed ApiModule for public interfacing
@@ -34,7 +35,8 @@ import { SemaphoreCache } from '@src/module.api/cache/semaphore.cache'
     MasternodesController,
     BlockController,
     OraclesController,
-    PricesController
+    PricesController,
+    StatsController
   ],
   providers: [
     { provide: APP_PIPE, useClass: ApiValidationPipe },

--- a/src/module.api/poolpair.service.ts
+++ b/src/module.api/poolpair.service.ts
@@ -6,8 +6,6 @@ import { SemaphoreCache } from '@src/module.api/cache/semaphore.cache'
 
 @Injectable()
 export class PoolPairService {
-  private readonly USDT_PER_DFI: BigNumber | undefined
-
   constructor (
     protected readonly rpcClient: JsonRpcClient,
     protected readonly cache: SemaphoreCache
@@ -62,7 +60,7 @@ export class PoolPairService {
     }
   }
 
-  private async getUSDT_PER_DFI (): Promise<BigNumber | undefined> {
+  async getUSDT_PER_DFI (): Promise<BigNumber | undefined> {
     return await this.cache.get<BigNumber>('USDT_PER_DFI', async () => {
       const pair = await this.getPoolPair('DFI', 'USDT')
       if (pair !== undefined) {

--- a/src/module.api/stats.controller.ts
+++ b/src/module.api/stats.controller.ts
@@ -25,12 +25,12 @@ export class StatsController {
 
     return {
       count: {
-        ...await this.cachedGet('count', this.getCount, 1800),
+        ...await this.cachedGet('count', this.getCount.bind(this), 1800),
         blocks: height
       },
-      burned: await this.cachedGet('burned', this.getBurned, 1800),
-      tvl: await this.cachedGet('tvl', this.getTVL, 300),
-      price: await this.cachedGet('price', this.getPrice, 300)
+      burned: await this.cachedGet('burned', this.getBurned.bind(this), 1800),
+      tvl: await this.cachedGet('tvl', this.getTVL.bind(this), 300),
+      price: await this.cachedGet('price', this.getPrice.bind(this), 300)
     }
   }
 

--- a/src/module.api/stats.controller.ts
+++ b/src/module.api/stats.controller.ts
@@ -1,0 +1,21 @@
+import { CACHE_MANAGER, Controller, Get, Inject } from '@nestjs/common'
+import { StatsData } from "@whale-api-client/api/stats";
+import { Interval } from "@nestjs/schedule";
+import { Cache } from "cache-manager";
+
+@Controller('/stats')
+export class StatsController {
+  constructor (@Inject(CACHE_MANAGER) protected readonly cacheManager: Cache) {
+  }
+
+  @Interval(60000)
+  private async refresh (): Promise<void> {
+    // TODO(fuxingloh):
+
+  }
+
+  @Get()
+  async get (): Promise<StatsData> {
+    return {}
+  }
+}

--- a/src/module.api/stats.controller.ts
+++ b/src/module.api/stats.controller.ts
@@ -1,21 +1,90 @@
-import { CACHE_MANAGER, Controller, Get, Inject } from '@nestjs/common'
-import { StatsData } from "@whale-api-client/api/stats";
-import { Interval } from "@nestjs/schedule";
-import { Cache } from "cache-manager";
+import { Controller, Get } from '@nestjs/common'
+import { StatsData } from '@whale-api-client/api/stats'
+import { SemaphoreCache } from '@src/module.api/cache/semaphore.cache'
+import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
+import { BlockMapper } from '@src/module.model/block'
+import { PoolPairService } from '@src/module.api/poolpair.service'
+import BigNumber from 'bignumber.js'
+import { PriceTickerMapper } from '@src/module.model/price.ticker'
 
 @Controller('/stats')
 export class StatsController {
-  constructor (@Inject(CACHE_MANAGER) protected readonly cacheManager: Cache) {
-  }
-
-  @Interval(60000)
-  private async refresh (): Promise<void> {
-    // TODO(fuxingloh):
-
+  constructor (
+    protected readonly blockMapper: BlockMapper,
+    protected readonly priceTickerMapper: PriceTickerMapper,
+    protected readonly poolPairService: PoolPairService,
+    protected readonly rpcClient: JsonRpcClient,
+    protected readonly cache: SemaphoreCache
+  ) {
   }
 
   @Get()
   async get (): Promise<StatsData> {
-    return {}
+    const block = await this.blockMapper.getHighest()
+    const height = requireValue(block?.height, 'count.blocks')
+
+    return {
+      count: {
+        ...await this.cachedGet('count', this.getCount, 1800),
+        blocks: height
+      },
+      burned: await this.cachedGet('burned', this.getBurned, 1800),
+      tvl: await this.cachedGet('tvl', this.getTVL, 300),
+      price: await this.cachedGet('price', this.getPrice, 300)
+    }
   }
+
+  private async cachedGet<T> (field: string, fetch: () => Promise<T>, ttl: number): Promise<T> {
+    const object = await this.cache.get(`StatsController.${field}`, fetch, { ttl })
+    return requireValue(object, field)
+  }
+
+  private async getCount (): Promise<StatsData['count']> {
+    const tokens = await this.rpcClient.token.listTokens({ including_start: true, start: 0, limit: 1000 }, false)
+    const prices = await this.priceTickerMapper.query(1000)
+
+    return {
+      blocks: 0,
+      prices: prices.length,
+      tokens: Object.keys(tokens).length
+    }
+  }
+
+  private async getTVL (): Promise<StatsData['tvl']> {
+    let dex = new BigNumber(0)
+    const pairs = await this.rpcClient.poolpair.listPoolPairs({ including_start: true, start: 0, limit: 1000 }, true)
+    for (const pair of Object.values(pairs)) {
+      const liq = await this.poolPairService.getTotalLiquidityUsd(pair)
+      dex = dex.plus(requireValue(liq, `tvl.dex.${pair.symbol}`))
+    }
+
+    return {
+      dex: dex.toNumber(),
+      total: dex.toNumber()
+    }
+  }
+
+  private async getBurned (): Promise<StatsData['burned']> {
+    const { emissionburn, amount, feeburn } = await this.rpcClient.account.getBurnInfo()
+    return {
+      address: amount.toNumber(),
+      emission: emissionburn.toNumber(),
+      fee: feeburn.toNumber(),
+      total: amount.plus(emissionburn).plus(feeburn).toNumber()
+    }
+  }
+
+  private async getPrice (): Promise<StatsData['price']> {
+    const usdt = await this.poolPairService.getUSDT_PER_DFI()
+    return {
+      usdt: requireValue(usdt, 'price.usdt').toNumber()
+    }
+  }
+}
+
+function requireValue<T> (value: T | undefined, name: string): T {
+  if (value === undefined) {
+    throw new Error(`failed to compute: ${name}`)
+  }
+  return value
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:

A single endpoint to get statistical data of the current chain. Data are cached at a different time intervals, only `count.blocks` won't be cached.

```ts
export interface StatsData {
  count: {
    blocks: number
    tokens: number
    prices: number
  }
  tvl: {
    total: number
    dex: number
  }
  burned: {
    total: number
    fee: number
    emission: number
    address: number
  }
  price: {
    usdt: number
  }
}
```

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #246

#### Additional comments?:
