### PR TITLE
fixed ApiPagedResponse.nextToken to just return `string | undefined`

### DIFF
--- a/packages/whale-api-client/src/whale.api.response.ts
+++ b/packages/whale-api-client/src/whale.api.response.ts
@@ -91,7 +91,7 @@ export class ApiPagedResponse<T> extends Array<T> {
   /**
    * @return {string} next token
    */
-  get nextToken (): string | number | undefined {
+  get nextToken (): string | undefined {
     return this._paginate.page?.next
   }
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

fixed ApiPagedResponse.nextToken to just return `string | undefined` since number is not allowed anymore
