### PR TITLE
added `feed?: OraclePriceFeed` in PriceOracle

### DIFF
--- a/packages/whale-api-client/__tests__/api/prices.test.ts
+++ b/packages/whale-api-client/__tests__/api/prices.test.ts
@@ -209,6 +209,23 @@ describe('oracles', () => {
         token: 'TA',
         currency: 'USD',
         weightage: expect.any(Number),
+        feed: {
+          id: expect.any(String),
+          key: expect.any(String),
+          sort: expect.any(String),
+          amount: expect.any(String),
+          currency: 'USD',
+          token: 'TA',
+          time: expect.any(Number),
+          oracleId: oracles[0].oracleId,
+          txid: expect.stringMatching(/[0-f]{64}/),
+          block: {
+            hash: expect.stringMatching(/[0-f]{64}/),
+            height: expect.any(Number),
+            medianTime: expect.any(Number),
+            time: expect.any(Number)
+          }
+        },
         block: {
           hash: expect.stringMatching(/[0-f]{64}/),
           height: expect.any(Number),

--- a/packages/whale-api-client/src/api/prices.ts
+++ b/packages/whale-api-client/src/api/prices.ts
@@ -1,5 +1,6 @@
 import { WhaleApiClient } from '../whale.api.client'
 import { ApiPagedResponse } from '../whale.api.response'
+import { OraclePriceFeed } from './oracles'
 
 /**
  * DeFi whale endpoint for price related services.
@@ -67,6 +68,11 @@ export interface PriceOracle {
   currency: string
   oracleId: string
   weightage: number
+
+  /**
+   * Optional as OraclePriceFeed might not be available e.g. newly initialized Oracle
+   */
+  feed?: OraclePriceFeed
 
   block: {
     hash: string


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->
 
/kind feature

#### What this PR does / why we need it:

Allow `feed?: OraclePriceFeed` in PriceOracle since it's always required for displaying at front end.