### PR TITLE
added a/b symbol for PoolPairData

### DIFF
--- a/packages/whale-api-client/__tests__/api/poolpairs.test.ts
+++ b/packages/whale-api-client/__tests__/api/poolpairs.test.ts
@@ -95,11 +95,13 @@ describe('list', () => {
       status: true,
       tokenA: {
         id: '2',
+        symbol: 'B',
         reserve: '50',
         blockCommission: '0'
       },
       tokenB: {
         id: '0',
+        symbol: 'DFI',
         reserve: '300',
         blockCommission: '0'
       },
@@ -167,11 +169,13 @@ describe('get', () => {
       status: true,
       tokenA: {
         id: expect.any(String),
+        symbol: 'A',
         reserve: '100',
         blockCommission: '0'
       },
       tokenB: {
-        id: expect.any(String),
+        id: '0',
+        symbol: 'DFI',
         reserve: '200',
         blockCommission: '0'
       },

--- a/packages/whale-api-client/src/api/poolpairs.ts
+++ b/packages/whale-api-client/src/api/poolpairs.ts
@@ -37,11 +37,13 @@ export interface PoolPairData {
   status: string
   tokenA: {
     id: string
+    symbol: string
     reserve: string // BigNumber
     blockCommission: string // BigNumber
   }
   tokenB: {
     id: string
+    symbol: string
     reserve: string // BigNumber
     blockCommission: string // BigNumber
   }

--- a/src/module.api/poolpair.controller.e2e.ts
+++ b/src/module.api/poolpair.controller.e2e.ts
@@ -95,11 +95,13 @@ describe('list', () => {
       status: true,
       tokenA: {
         id: '2',
+        symbol: 'B',
         reserve: '50',
         blockCommission: '0'
       },
       tokenB: {
         id: '0',
+        symbol: 'DFI',
         reserve: '300',
         blockCommission: '0'
       },
@@ -171,11 +173,13 @@ describe('get', () => {
       status: true,
       tokenA: {
         id: expect.any(String),
+        symbol: 'A',
         reserve: '100',
         blockCommission: '0'
       },
       tokenB: {
-        id: expect.any(String),
+        id: '0',
+        symbol: 'DFI',
         reserve: '200',
         blockCommission: '0'
       },

--- a/src/module.api/poolpair.controller.spec.ts
+++ b/src/module.api/poolpair.controller.spec.ts
@@ -128,11 +128,13 @@ describe('list', () => {
       status: true,
       tokenA: {
         id: '2',
+        symbol: 'B',
         reserve: '50',
         blockCommission: '0'
       },
       tokenB: {
         id: '0',
+        symbol: 'DFI',
         reserve: '300',
         blockCommission: '0'
       },
@@ -204,11 +206,13 @@ describe('get', () => {
       status: true,
       tokenA: {
         id: expect.any(String),
+        symbol: 'USDT',
         reserve: '100',
         blockCommission: '0'
       },
       tokenB: {
-        id: expect.any(String),
+        id: '0',
+        symbol: 'DFI',
         reserve: '200',
         blockCommission: '0'
       },

--- a/src/module.api/poolpair.controller.ts
+++ b/src/module.api/poolpair.controller.ts
@@ -63,17 +63,20 @@ export class PoolPairController {
 }
 
 function mapPoolPair (id: string, info: PoolPairInfo, totalLiquidityUsd?: BigNumber, apr?: PoolPairData['apr']): PoolPairData {
+  const [symbolA, symbolB] = info.symbol.split('-')
   return {
     id: id,
     symbol: info.symbol,
     name: info.name,
     status: info.status,
     tokenA: {
+      symbol: symbolA,
       id: info.idTokenA,
       reserve: info.reserveA.toFixed(),
       blockCommission: info.blockCommissionA.toFixed()
     },
     tokenB: {
+      symbol: symbolB,
       id: info.idTokenB,
       reserve: info.reserveB.toFixed(),
       blockCommission: info.blockCommissionB.toFixed()


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:

Instead of having to `split('-')` the pool pair data symbol, this PR will include it within `a` and `b`.
