### PR TITLE
prefix version can now be overridden in production

### DIFF
--- a/packages/whale-api-client/src/api/address.ts
+++ b/packages/whale-api-client/src/api/address.ts
@@ -95,7 +95,7 @@ export interface AddressAggregation {
     hex: string
   }
 
-  statistic: {
+  statistic: { // TODO(fuxingloh): should be named `count: {}`, too late to change now.
     txCount: number
     txInCount: number
     txOutCount: number

--- a/packages/whale-api-client/src/api/blocks.ts
+++ b/packages/whale-api-client/src/api/blocks.ts
@@ -47,7 +47,7 @@ export interface Block {
   time: number // --------------| block time in seconds since epoch
   medianTime: number // --------| median time of the past 11 block timestamps
 
-  transactionCount: number
+  transactionCount: number // TODO(fuxingloh): should be structured as `count: { transaction: number }`, too late to change now
 
   difficulty: number // --------| difficulty of the block.
 

--- a/packages/whale-api-client/src/api/tokens.ts
+++ b/packages/whale-api-client/src/api/tokens.ts
@@ -43,7 +43,13 @@ export interface TokenData {
   isLPS: boolean
   finalized: boolean
   minted: string // BigNumber
-  creation: { tx: string, height: number }
-  destruction: { tx: string, height: number }
+  creation: {
+    tx: string
+    height: number
+  }
+  destruction: {
+    tx: string
+    height: number
+  }
   collateralAddress?: string
 }

--- a/packages/whale-api-client/src/whale.api.client.ts
+++ b/packages/whale-api-client/src/whale.api.client.ts
@@ -31,7 +31,7 @@ export interface WhaleApiClientOptions {
 
   /**
    * Version of API
-   * `v{major}.{minor}`: `v${number}.${number}`
+   * `v{major}.{minor}` or `v{major}`
    */
   version?: string
 

--- a/src/app.configuration.ts
+++ b/src/app.configuration.ts
@@ -6,10 +6,14 @@
  */
 export const AppConfiguration = (): any => ({
   isProd: process.env.NODE_ENV === 'production',
+  /**
+   * Allows you to override whale endpoint version.
+   */
+  version: process.env.WHALE_VERSION,
+  network: process.env.WHALE_NETWORK,
   defid: {
     url: process.env.WHALE_DEFID_URL
   },
-  network: process.env.WHALE_NETWORK,
   database: {
     // Provider can only be set via environmental variable
     provider: process.env.WHALE_DATABASE_PROVIDER,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -53,8 +53,7 @@ export class AppModule {
    * - GlobalPrefix 'v{major}.{minor}/${network}' e.g. 'v0.0/regtest'
    */
   static configure (app: NestFastifyApplication): void {
-    const [major, minor] = packageJson.version.split('.')
-    const version = `v${major}.${minor}`
+    const version = this.getVersion(app)
     const network = app.get(ConfigService).get<string>('network') as string
 
     app.enableCors({
@@ -70,5 +69,14 @@ export class AppModule {
         '/_actuator/probes/readiness'
       ]
     })
+  }
+
+  /**
+   * @return string version from ConfigService, default to package.json v{major}.{minor} if not found.
+   */
+  static getVersion (app: NestFastifyApplication): string {
+    const [major, minor] = packageJson.version.split('.')
+    const defaultVersion = `v${major}.${minor}`
+    return app.get(ConfigService).get<string>('version', defaultVersion)
   }
 }

--- a/src/version.e2e.ts
+++ b/src/version.e2e.ts
@@ -1,0 +1,77 @@
+import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
+import { NestFastifyApplication } from '@nestjs/platform-fastify'
+import { newFastifyAdapter } from '@src/fastify'
+import { AppModule } from '@src/app.module'
+import { Test } from '@nestjs/testing'
+import { ConfigService } from '@nestjs/config'
+
+const container = new MasterNodeRegTestContainer()
+let app: NestFastifyApplication
+
+class VersionConfigService extends ConfigService {
+  constructor (rpcUrl: string) {
+    super({
+      defid: {
+        url: rpcUrl
+      },
+      version: 'v0',
+      network: 'regtest',
+      database: {
+        provider: 'memory'
+      }
+    })
+  }
+}
+
+beforeAll(async () => {
+  await container.start()
+  await container.generate(1)
+
+  const url = await container.getCachedRpcUrl()
+  const module = await Test.createTestingModule({
+    imports: [AppModule.forRoot('memory')]
+  })
+    .overrideProvider(ConfigService).useValue(new VersionConfigService(url))
+    .compile()
+
+  app = module.createNestApplication<NestFastifyApplication>(
+    newFastifyAdapter({ logger: false })
+  )
+  AppModule.configure(app)
+  await app.init()
+})
+
+afterAll(async () => {
+  try {
+    await app.close()
+  } finally {
+    await container.stop()
+  }
+})
+
+it('should GET /v0/regtest/tokens with overridden endpoint', async () => {
+  const res = await app.inject({
+    method: 'GET',
+    url: '/v0/regtest/tokens'
+  })
+
+  expect(res.statusCode).toStrictEqual(200)
+  expect(res.json()).toStrictEqual({
+    data: [
+      expect.objectContaining({
+        id: '0',
+        symbol: 'DFI',
+        symbolKey: 'DFI'
+      })
+    ]
+  })
+})
+
+it('should fail GET with /v0.0/regtest/tokens as endpoint is overridden', async () => {
+  const res = await app.inject({
+    method: 'GET',
+    url: '/v0.0/regtest/tokens'
+  })
+
+  expect(res.statusCode).toStrictEqual(404)
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:

Allow endpoint prefix version to be overridden in production. 

> Instead of having a heavy infrastructure design with complex routing, this removes infra overhead and allows you to choose which is the main deployment by set `v0`.
