### PR TITLE
fix WhaleApiClient options to create a new options instead of assigning

### DIFF
--- a/packages/whale-api-client/src/whale.api.client.ts
+++ b/packages/whale-api-client/src/whale.api.client.ts
@@ -44,7 +44,7 @@ export interface WhaleApiClientOptions {
 /**
  * WhaleApiClient default options
  */
-export const DefaultOptions: WhaleApiClientOptions = {
+const DEFAULT_OPTIONS: WhaleApiClientOptions = {
   url: 'https://ocean.defichain.com',
   timeout: 60000,
   version: version,
@@ -78,7 +78,7 @@ export class WhaleApiClient {
   constructor (
     protected readonly options: WhaleApiClientOptions
   ) {
-    this.options = Object.assign(DefaultOptions, options ?? {})
+    this.options = { ...DEFAULT_OPTIONS, ...options }
     this.options.url = this.options.url.replace(/\/$/, '')
   }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

Override the options WhaleApiClient creates the side effect of permanently overriding it.