### PR TITLE
masternode own indexer & model

### DIFF
--- a/src/module.model/masternode.own.spec.ts
+++ b/src/module.model/masternode.own.spec.ts
@@ -1,0 +1,83 @@
+import { Database } from '@src/module.database/database'
+import { Test } from '@nestjs/testing'
+import { MemoryDatabaseModule } from '@src/module.database/provider.memory/module'
+import { LevelDatabase } from '@src/module.database/provider.level/level.database'
+import { MasternodeOwnMapper } from '@src/module.model/masternode.own'
+
+let database: Database
+let mapper: MasternodeOwnMapper
+
+beforeAll(async () => {
+  const app = await Test.createTestingModule({
+    imports: [MemoryDatabaseModule],
+    providers: [MasternodeOwnMapper]
+  }).compile()
+
+  database = app.get<Database>(Database)
+  mapper = app.get<MasternodeOwnMapper>(MasternodeOwnMapper)
+})
+
+beforeEach(async () => {
+  async function put (
+    masternodeId: string, ownerAddress: string, operatorAddress: string, height: number
+  ): Promise<void> {
+    await mapper.put({
+      id: masternodeId,
+      ownerAddress: ownerAddress,
+      operatorAddress: operatorAddress,
+      creationHeight: 0,
+      resignHeight: 0,
+      resignTx: undefined,
+      mintedBlocks: 1,
+      timelock: 0,
+      local: true,
+      block: { hash: '', height: height, time: 0, medianTime: 0 }
+    })
+  }
+
+  await put('mnA1', 'mnA', 'mnAa', 1)
+  await put('mnA2', 'mnA', 'mnAb', 2)
+  await put('mnA3', 'mnA', 'mnAc', 3)
+
+  await put('mnB1', 'mnB', 'mnBa', 20)
+})
+
+afterEach(async () => {
+  await (database as LevelDatabase).clear()
+})
+
+it('should query', async () => {
+  {
+    const list = await mapper.query('mnA', 10)
+    expect(list.length).toStrictEqual(3)
+
+    expect(list[0].block.height).toStrictEqual(3)
+    expect(list[0].id).toStrictEqual('mnA3')
+    expect(list[0].operatorAddress).toStrictEqual('mnAc')
+
+    expect(list[1].block.height).toStrictEqual(2)
+    expect(list[1].id).toStrictEqual('mnA2')
+    expect(list[1].operatorAddress).toStrictEqual('mnAb')
+
+    expect(list[2].block.height).toStrictEqual(1)
+    expect(list[2].id).toStrictEqual('mnA1')
+    expect(list[2].operatorAddress).toStrictEqual('mnAa')
+  }
+
+  {
+    const list = await mapper.query('mnB', 10)
+    expect(list.length).toStrictEqual(1)
+    expect(list[0].block.height).toStrictEqual(20)
+    expect(list[0].id).toStrictEqual('mnB1')
+    expect(list[0].operatorAddress).toStrictEqual('mnBa')
+  }
+})
+
+it('should delete', async () => {
+  const list = await mapper.query('mnA', 10)
+  expect(list.length).toStrictEqual(3)
+
+  await mapper.delete(list[1].id)
+  const deleted = await mapper.query('mnA', 10)
+  expect(deleted.length).toStrictEqual(2)
+})

--- a/src/module.model/masternode.own.ts
+++ b/src/module.model/masternode.own.ts
@@ -1,0 +1,75 @@
+import { Model, ModelMapping } from '@src/module.database/model'
+import { Injectable } from '@nestjs/common'
+import { Database, SortOrder } from '@src/module.database/database'
+
+const MasternodeOwnMapping: ModelMapping<MasternodeOwn> = {
+  type: 'masternode_own_aggregation',
+  index: {
+    owneraddress_height: {
+      name: 'masternode_own_aggregation_owneraddress_height',
+      partition: {
+        type: 'string',
+        key: (b: MasternodeOwn) => b.ownerAddress
+      },
+      sort: {
+        type: 'number',
+        key: (b: MasternodeOwn) => b.block.height
+      }
+    }
+  }
+}
+
+@Injectable()
+export class MasternodeOwnMapper {
+  public constructor (protected readonly database: Database) {
+  }
+
+  async getLatest (ownerAddress: string): Promise<MasternodeOwn | undefined> {
+    const aggregations = await this.database.query(MasternodeOwnMapping.index.owneraddress_height, {
+      partitionKey: ownerAddress,
+      order: SortOrder.DESC,
+      limit: 1
+    })
+    return aggregations.length === 0 ? undefined : aggregations[0]
+  }
+
+  async query (ownerAddress: string, limit: number, lt?: string): Promise<MasternodeOwn[]> {
+    return await this.database.query(MasternodeOwnMapping.index.owneraddress_height, {
+      partitionKey: ownerAddress,
+      limit: limit,
+      order: SortOrder.DESC,
+      lt: lt
+    })
+  }
+
+  async get (id: string): Promise<MasternodeOwn | undefined> {
+    return await this.database.get(MasternodeOwnMapping, id)
+  }
+
+  async put (masternodeOwn: MasternodeOwn): Promise<void> {
+    return await this.database.put(MasternodeOwnMapping, masternodeOwn)
+  }
+
+  async delete (id: string): Promise<void> {
+    return await this.database.delete(MasternodeOwnMapping, id)
+  }
+}
+
+export interface MasternodeOwn extends Model {
+  id: string // masternodeId
+  ownerAddress: string // partition
+  operatorAddress: string
+  creationHeight: number
+  resignHeight: number
+  resignTx?: string
+  mintedBlocks: number
+  timelock: number // number of weeks locked up
+  local: boolean
+
+  block: {
+    hash: string
+    height: number // sort
+    time: number
+    medianTime: number
+  }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:
Listing particular user own masternode
eg: wallet calls `/{user collateral addres}/masternodes` to retrieve own mn
resp: 
```ts
[
      {
        id: 'mnA3',
        ownerAddress: 'mnA',
        operatorAddress: 'mnAc',
        creationHeight: 0,
        resignHeight: 0,
        mintedBlocks: 1,
        timelock: 0,
        local: true,
        block: { hash: '', height: 3, time: 0, medianTime: 0 }
      },
      {
        id: 'mnA2',
        ownerAddress: 'mnA',
        operatorAddress: 'mnAb',
        creationHeight: 0,
        resignHeight: 0,
        mintedBlocks: 1,
        timelock: 0,
        local: true,
        block: { hash: '', height: 2, time: 0, medianTime: 0 }
      },
      {
        id: 'mnA1',
        ownerAddress: 'mnA',
        operatorAddress: 'mnAa',
        creationHeight: 0,
        resignHeight: 0,
        mintedBlocks: 1,
        timelock: 0,
        local: true,
        block: { hash: '', height: 1, time: 0, medianTime: 0 }
      }
]
```

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #feature

#### Additional comments?:
Blocked by 
https://github.com/DeFiCh/jellyfish/pull/534
https://github.com/DeFiCh/whale/pull/344
mn targetMultiplier