### PR TITLE
Fix block minted issue

### DIFF
--- a/src/module.indexer/model/block.minted.e2e.ts
+++ b/src/module.indexer/model/block.minted.e2e.ts
@@ -1,0 +1,31 @@
+import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
+import { createTestingApp, stopTestingApp } from '@src/e2e.module'
+import { NestFastifyApplication } from '@nestjs/platform-fastify'
+import { BlockMintedIndexer } from './block.minted'
+import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
+
+const container = new MasterNodeRegTestContainer()
+let app: NestFastifyApplication
+let client: JsonRpcClient
+
+beforeAll(async () => {
+  await container.start()
+  await container.waitForReady()
+  await container.generate(21)
+
+  app = await createTestingApp(container)
+  client = new JsonRpcClient(await container.getCachedRpcUrl())
+})
+
+afterAll(async () => {
+  await stopTestingApp(container, app)
+})
+
+it('should index block 0', async () => {
+  const blockMintedIndexer = app.get(BlockMintedIndexer)
+
+  const hash = await client.blockchain.getBlockHash(0)
+  const block = await client.blockchain.getBlock(hash, 2)
+
+  await expect(blockMintedIndexer.index(block)).resolves.not.toThrow()
+})

--- a/src/module.indexer/model/block.minted.ts
+++ b/src/module.indexer/model/block.minted.ts
@@ -11,16 +11,20 @@ export class BlockMintedIndexer extends Indexer {
   }
 
   async index (block: RawBlock): Promise<void> {
-    const mn = await this.masternodeMapper.get(block.masternode)
-    if (mn !== undefined && block.masternode !== undefined) {
-      await this.masternodeMapper.put({ ...mn, mintedBlocks: mn.mintedBlocks + 1 })
+    if (block.masternode !== undefined) {
+      const mn = await this.masternodeMapper.get(block.masternode)
+      if (mn !== undefined) {
+        await this.masternodeMapper.put({ ...mn, mintedBlocks: mn.mintedBlocks + 1 })
+      }
     }
   }
 
   async invalidate (block: RawBlock): Promise<void> {
-    const mn = await this.masternodeMapper.get(block.masternode)
-    if (mn !== undefined && block.masternode !== undefined) {
-      await this.masternodeMapper.put({ ...mn, mintedBlocks: mn.mintedBlocks - 1 })
+    if (block.masternode !== undefined) {
+      const mn = await this.masternodeMapper.get(block.masternode)
+      if (mn !== undefined) {
+        await this.masternodeMapper.put({ ...mn, mintedBlocks: mn.mintedBlocks - 1 })
+      }
     }
   }
 }

--- a/src/module.indexer/rpc.block.provider.spec.ts
+++ b/src/module.indexer/rpc.block.provider.spec.ts
@@ -1,0 +1,21 @@
+import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
+import { createTestingApp, stopTestingApp } from '@src/e2e.module'
+import { NestFastifyApplication } from '@nestjs/platform-fastify'
+import { RPCBlockProvider } from './rpc.block.provider'
+
+const container = new MasterNodeRegTestContainer()
+let app: NestFastifyApplication
+
+beforeAll(async () => {
+  await container.start()
+  app = await createTestingApp(container)
+})
+
+afterAll(async () => {
+  await stopTestingApp(container, app)
+})
+
+it('should index genesis without throwing', async () => {
+  const rpcBlockProvider = app.get(RPCBlockProvider)
+  await expect(rpcBlockProvider.indexGenesis()).resolves.not.toThrow()
+})

--- a/src/module.indexer/rpc.block.provider.ts
+++ b/src/module.indexer/rpc.block.provider.ts
@@ -77,7 +77,7 @@ export class RPCBlockProvider {
     return hash === indexed.hash
   }
 
-  private async indexGenesis (): Promise<boolean> {
+  public async indexGenesis (): Promise<boolean> {
     const hash = await this.client.blockchain.getBlockHash(0)
     const block = await this.client.blockchain.getBlock(hash, 2)
     await this.indexer.index(block)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

This fixes an issue in the block minted mapper that causes the following error print out and causes the `indexGenesis` function to exit early:

```
[Nest] 10720  - 31/08/2021, 8:00:46 pm   ERROR [RPCBlockProvider] failed exceptionally
[Nest] 10720  - 31/08/2021, 8:00:46 pm   ERROR [RPCBlockProvider] ReadError: key cannot be `null` or `undefined`
```

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:
