### PR TITLE
`/blocks` & `/transactions` improvement

### DIFF
--- a/packages/whale-api-client/__tests__/api/blocks.test.ts
+++ b/packages/whale-api-client/__tests__/api/blocks.test.ts
@@ -53,7 +53,7 @@ describe('list', () => {
     const first = await client.blocks.list(35)
 
     expect(first.length).toStrictEqual(35)
-    expect(first[0]).toStrictEqual(ExpectedBlock)
+    expect(first[0]).toStrictEqual({ ...ExpectedBlock, reward: '33.33000000' })
     expect(first[0].height).toBeGreaterThanOrEqual(100 - 35)
     expect(first[34].height).toBeGreaterThanOrEqual(first[0].height - 35)
 
@@ -69,14 +69,14 @@ describe('list', () => {
     const first = await client.blocks.list(100)
 
     expect(first.length).toStrictEqual(60)
-    expect(first[0]).toStrictEqual(ExpectedBlock)
+    expect(first[0]).toStrictEqual({ ...ExpectedBlock, reward: '33.33000000' })
   })
 
   it('should get paginated list of blocks when next is out of range', async () => {
     const blocks = await client.blocks.list(15, '1000000')
     expect(blocks.length).toStrictEqual(15)
 
-    expect(blocks[0]).toStrictEqual(ExpectedBlock)
+    expect(blocks[0]).toStrictEqual({ ...ExpectedBlock, reward: '33.33000000' })
     expect(blocks[0].height).toBeGreaterThanOrEqual(40)
   })
 
@@ -90,7 +90,7 @@ describe('list', () => {
     const blocks = await client.blocks.list(60)
     expect(blocks.length).toBeGreaterThanOrEqual(40)
 
-    expect(blocks[0]).toStrictEqual(ExpectedBlock)
+    expect(blocks[0]).toStrictEqual({ ...ExpectedBlock, reward: '33.33000000' })
     expect(blocks[0].height).toBeGreaterThanOrEqual(40)
   })
 })
@@ -99,14 +99,14 @@ describe('get', () => {
   it('should get block through height', async () => {
     const block = await client.blocks.get('37')
 
-    expect(block).toStrictEqual(ExpectedBlock)
+    expect(block).toStrictEqual({ ...ExpectedBlock, reward: '33.33000000' })
     expect(block?.height).toStrictEqual(37)
   })
 
   it('should get block through hash', async () => {
     const blockHash = await container.call('getblockhash', [37])
     const block = await client.blocks.get(blockHash)
-    expect(block).toStrictEqual(ExpectedBlock)
+    expect(block).toStrictEqual({ ...ExpectedBlock, reward: '33.33000000' })
     expect(block?.height).toStrictEqual(37)
   })
 
@@ -144,7 +144,11 @@ describe('getTransactions', () => {
   it('should getTransactions through hash', async () => {
     const blockHash = await container.call('getblockhash', [37])
     const transactions = await client.blocks.getTransactions(blockHash)
-    expect(transactions[0]).toStrictEqual(ExpectedTransaction)
+    expect(transactions[0]).toStrictEqual({
+      ...ExpectedTransaction,
+      totalVOut: '38.24000000',
+      sort: expect.any(String)
+    })
     expect(transactions[0].block.height).toStrictEqual(37)
   })
 

--- a/packages/whale-api-client/__tests__/api/blocks.test.ts
+++ b/packages/whale-api-client/__tests__/api/blocks.test.ts
@@ -125,7 +125,7 @@ describe('get', () => {
 describe('getTransactions', () => {
   const ExpectedTransaction = {
     id: expect.stringMatching(/[0-f]{64}/),
-    sort: expect.any(String),
+    order: expect.any(Number),
     block: {
       hash: expect.stringMatching(/[0-f]{64}/),
       height: expect.any(Number),

--- a/packages/whale-api-client/__tests__/api/blocks.test.ts
+++ b/packages/whale-api-client/__tests__/api/blocks.test.ts
@@ -125,6 +125,7 @@ describe('get', () => {
 describe('getTransactions', () => {
   const ExpectedTransaction = {
     id: expect.stringMatching(/[0-f]{64}/),
+    sort: expect.any(String),
     block: {
       hash: expect.stringMatching(/[0-f]{64}/),
       height: expect.any(Number),
@@ -140,8 +141,7 @@ describe('getTransactions', () => {
     lockTime: expect.any(Number),
     vinCount: expect.any(Number),
     voutCount: expect.any(Number),
-    totalVoutValue: expect.any(String),
-    sort: expect.any(String)
+    totalVoutValue: expect.any(String)
   }
 
   it('should getTransactions through hash', async () => {

--- a/packages/whale-api-client/__tests__/api/blocks.test.ts
+++ b/packages/whale-api-client/__tests__/api/blocks.test.ts
@@ -45,7 +45,8 @@ const ExpectedBlock = {
   merkleroot: expect.stringMatching(/[0-f]{64}/),
   size: expect.any(Number),
   sizeStripped: expect.any(Number),
-  weight: expect.any(Number)
+  weight: expect.any(Number),
+  reward: expect.any(String)
 }
 
 describe('list', () => {
@@ -53,7 +54,7 @@ describe('list', () => {
     const first = await client.blocks.list(35)
 
     expect(first.length).toStrictEqual(35)
-    expect(first[0]).toStrictEqual({ ...ExpectedBlock, reward: '33.33000000' })
+    expect(first[0]).toStrictEqual(ExpectedBlock)
     expect(first[0].height).toBeGreaterThanOrEqual(100 - 35)
     expect(first[34].height).toBeGreaterThanOrEqual(first[0].height - 35)
 
@@ -69,14 +70,14 @@ describe('list', () => {
     const first = await client.blocks.list(100)
 
     expect(first.length).toStrictEqual(60)
-    expect(first[0]).toStrictEqual({ ...ExpectedBlock, reward: '33.33000000' })
+    expect(first[0]).toStrictEqual(ExpectedBlock)
   })
 
   it('should get paginated list of blocks when next is out of range', async () => {
     const blocks = await client.blocks.list(15, '1000000')
     expect(blocks.length).toStrictEqual(15)
 
-    expect(blocks[0]).toStrictEqual({ ...ExpectedBlock, reward: '33.33000000' })
+    expect(blocks[0]).toStrictEqual(ExpectedBlock)
     expect(blocks[0].height).toBeGreaterThanOrEqual(40)
   })
 
@@ -90,7 +91,7 @@ describe('list', () => {
     const blocks = await client.blocks.list(60)
     expect(blocks.length).toBeGreaterThanOrEqual(40)
 
-    expect(blocks[0]).toStrictEqual({ ...ExpectedBlock, reward: '33.33000000' })
+    expect(blocks[0]).toStrictEqual(ExpectedBlock)
     expect(blocks[0].height).toBeGreaterThanOrEqual(40)
   })
 })
@@ -99,14 +100,14 @@ describe('get', () => {
   it('should get block through height', async () => {
     const block = await client.blocks.get('37')
 
-    expect(block).toStrictEqual({ ...ExpectedBlock, reward: '33.33000000' })
+    expect(block).toStrictEqual(ExpectedBlock)
     expect(block?.height).toStrictEqual(37)
   })
 
   it('should get block through hash', async () => {
     const blockHash = await container.call('getblockhash', [37])
     const block = await client.blocks.get(blockHash)
-    expect(block).toStrictEqual({ ...ExpectedBlock, reward: '33.33000000' })
+    expect(block).toStrictEqual(ExpectedBlock)
     expect(block?.height).toStrictEqual(37)
   })
 
@@ -138,17 +139,15 @@ describe('getTransactions', () => {
     weight: expect.any(Number),
     lockTime: expect.any(Number),
     vinCount: expect.any(Number),
-    voutCount: expect.any(Number)
+    voutCount: expect.any(Number),
+    totalVoutValue: expect.any(String),
+    sort: expect.any(String)
   }
 
   it('should getTransactions through hash', async () => {
     const blockHash = await container.call('getblockhash', [37])
     const transactions = await client.blocks.getTransactions(blockHash)
-    expect(transactions[0]).toStrictEqual({
-      ...ExpectedTransaction,
-      totalVOut: '38.24000000',
-      sort: expect.any(String)
-    })
+    expect(transactions[0]).toStrictEqual(ExpectedTransaction)
     expect(transactions[0].block.height).toStrictEqual(37)
   })
 

--- a/packages/whale-api-client/__tests__/api/transaction.test.ts
+++ b/packages/whale-api-client/__tests__/api/transaction.test.ts
@@ -69,6 +69,7 @@ describe('get', () => {
     const transaction = await client.transactions.get(txid)
     expect(transaction).toStrictEqual({
       id: txid,
+      sort: expect.any(String),
       block: {
         hash: expect.any(String),
         height: expect.any(Number),

--- a/packages/whale-api-client/__tests__/api/transaction.test.ts
+++ b/packages/whale-api-client/__tests__/api/transaction.test.ts
@@ -84,7 +84,7 @@ describe('get', () => {
       lockTime: expect.any(Number),
       vinCount: expect.any(Number),
       voutCount: expect.any(Number),
-      totalVOut: expect.any(String)
+      totalVoutValue: expect.any(String)
     })
   })
 

--- a/packages/whale-api-client/__tests__/api/transaction.test.ts
+++ b/packages/whale-api-client/__tests__/api/transaction.test.ts
@@ -69,7 +69,7 @@ describe('get', () => {
     const transaction = await client.transactions.get(txid)
     expect(transaction).toStrictEqual({
       id: txid,
-      sort: expect.any(String),
+      order: expect.any(Number),
       block: {
         hash: expect.any(String),
         height: expect.any(Number),

--- a/packages/whale-api-client/__tests__/api/transaction.test.ts
+++ b/packages/whale-api-client/__tests__/api/transaction.test.ts
@@ -83,7 +83,8 @@ describe('get', () => {
       weight: expect.any(Number),
       lockTime: expect.any(Number),
       vinCount: expect.any(Number),
-      voutCount: expect.any(Number)
+      voutCount: expect.any(Number),
+      totalVOut: expect.any(String)
     })
   })
 

--- a/packages/whale-api-client/src/api/blocks.ts
+++ b/packages/whale-api-client/src/api/blocks.ts
@@ -54,6 +54,7 @@ export interface Block {
   masternode: string
   minter: string
   minterBlockCount: number
+  reward: string // ------------| reward string as decimal
 
   stakeModifier: string
   merkleroot: string

--- a/packages/whale-api-client/src/api/transactions.ts
+++ b/packages/whale-api-client/src/api/transactions.ts
@@ -54,6 +54,7 @@ export interface Transaction {
   lockTime: number
   vinCount: number
   voutCount: number
+  totalVOut: string
 }
 
 /**

--- a/packages/whale-api-client/src/api/transactions.ts
+++ b/packages/whale-api-client/src/api/transactions.ts
@@ -54,7 +54,7 @@ export interface Transaction {
   lockTime: number
   vinCount: number
   voutCount: number
-  totalVOut: string
+  totalVoutValue: string
 }
 
 /**

--- a/src/module.api/block.controller.e2e.ts
+++ b/src/module.api/block.controller.e2e.ts
@@ -95,7 +95,7 @@ describe('list', () => {
 describe('getTransactions', () => {
   it('should get transactions from a block by hash', async () => {
     const blockHash = await container.call('getblockhash', [100])
-    const paginatedTransactions = await controller.getTransactions(blockHash, { size: 30, next: '10' })
+    const paginatedTransactions = await controller.getTransactions(blockHash, { size: 30 })
 
     expect(paginatedTransactions.data.length).toBeGreaterThanOrEqual(1)
     expect(paginatedTransactions.data[0].block.height).toStrictEqual(100)
@@ -121,7 +121,7 @@ describe('getTransactions', () => {
 
   it('should list transactions in the right order', async () => {
     const blockHash = await container.call('getblockhash', [103])
-    const paginatedTransactions = await controller.getTransactions(blockHash, { size: 30, next: '10' })
+    const paginatedTransactions = await controller.getTransactions(blockHash, { size: 30 })
 
     expect(paginatedTransactions.data.length).toBeGreaterThanOrEqual(4)
     expect(paginatedTransactions.data[0].block.height).toStrictEqual(103)

--- a/src/module.api/block.controller.e2e.ts
+++ b/src/module.api/block.controller.e2e.ts
@@ -102,7 +102,7 @@ describe('getTransactions', () => {
   })
 
   it('getTransactions should not get transactions by height', async () => {
-    const paginatedTransactions = await controller.getTransactions('0', { size: 30, next: '10' })
+    const paginatedTransactions = await controller.getTransactions('0', { size: 30 })
 
     expect(paginatedTransactions.data.length).toStrictEqual(0)
   })

--- a/src/module.api/block.controller.ts
+++ b/src/module.api/block.controller.ts
@@ -37,21 +37,11 @@ export class BlockController {
   async get (@Param('id') hashOrHeight: string): Promise<Block | undefined> {
     const height = parseHeight(hashOrHeight)
     if (height !== undefined) {
-      const block = await this.blockMapper.getByHeight(height)
-      if (block === undefined) {
-        return undefined
-      }
-
-      return block
+      return await this.blockMapper.getByHeight(height)
     }
 
     if (isSHA256Hash(hashOrHeight)) {
-      const block = await this.blockMapper.getByHash(hashOrHeight)
-      if (block === undefined) {
-        return undefined
-      }
-
-      return block
+      return await this.blockMapper.getByHash(hashOrHeight)
     }
   }
 

--- a/src/module.api/block.controller.ts
+++ b/src/module.api/block.controller.ts
@@ -1,6 +1,5 @@
 import { Controller, Get, Param, Query } from '@nestjs/common'
-import { BlockMapper, Block as ModelBlock } from '@src/module.model/block'
-import { Block } from '@whale-api-client/api/blocks'
+import { BlockMapper, Block } from '@src/module.model/block'
 import { Transaction, TransactionMapper } from '@src/module.model/transaction'
 import { ApiPagedResponse } from '@src/module.api/_core/api.paged.response'
 import { PaginationQuery } from '@src/module.api/_core/api.query'
@@ -29,7 +28,7 @@ export class BlockController {
   ): Promise<ApiPagedResponse<Block>> {
     const height = parseHeight(query.next)
     const blocks = await this.blockMapper.queryByHeight(query.size, height)
-    return ApiPagedResponse.of(blocks.map(block => mapBlock(block)), query.size, item => {
+    return ApiPagedResponse.of(blocks, query.size, item => {
       return item.height.toString()
     })
   }
@@ -43,7 +42,7 @@ export class BlockController {
         return undefined
       }
 
-      return mapBlock(block)
+      return block
     }
 
     if (isSHA256Hash(hashOrHeight)) {
@@ -52,7 +51,7 @@ export class BlockController {
         return undefined
       }
 
-      return mapBlock(block)
+      return block
     }
   }
 
@@ -62,32 +61,9 @@ export class BlockController {
       return ApiPagedResponse.empty()
     }
 
-    const transactions = await this.transactionMapper.queryByBlockHash(hash, query.size, query.next)
+    const transactions = await this.transactionMapper.queryByBlockHash(hash, query.size, parseHeight(query.next))
     return ApiPagedResponse.of(transactions, query.size, transaction => {
-      return transaction.id
+      return transaction.order.toString()
     })
-  }
-}
-
-function mapBlock (block: ModelBlock): Block {
-  return {
-    id: block.id,
-    hash: block.hash,
-    previousHash: block.previousHash,
-    height: block.height,
-    version: block.version,
-    time: block.time,
-    medianTime: block.medianTime,
-    transactionCount: block.transactionCount,
-    difficulty: block.difficulty,
-    masternode: block.masternode,
-    minter: block.minter,
-    minterBlockCount: block.minterBlockCount,
-    stakeModifier: block.stakeModifier,
-    merkleroot: block.merkleroot,
-    size: block.size,
-    sizeStripped: block.sizeStripped,
-    weight: block.weight,
-    reward: block.reward
   }
 }

--- a/src/module.api/block.controller.ts
+++ b/src/module.api/block.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, NotFoundException, Param, Query } from '@nestjs/common'
+import { Controller, Get, Param, Query } from '@nestjs/common'
 import { BlockMapper, Block as ModelBlock } from '@src/module.model/block'
 import { Block } from '@whale-api-client/api/blocks'
 import { Transaction, TransactionMapper } from '@src/module.model/transaction'
@@ -40,7 +40,7 @@ export class BlockController {
     if (height !== undefined) {
       const block = await this.blockMapper.getByHeight(height)
       if (block === undefined) {
-        throw new NotFoundException('Unable to find block')
+        return undefined
       }
 
       return mapBlock(block)
@@ -49,7 +49,7 @@ export class BlockController {
     if (isSHA256Hash(hashOrHeight)) {
       const block = await this.blockMapper.getByHash(hashOrHeight)
       if (block === undefined) {
-        throw new NotFoundException('Unable to find block')
+        return undefined
       }
 
       return mapBlock(block)

--- a/src/module.api/transaction.controller.e2e.ts
+++ b/src/module.api/transaction.controller.e2e.ts
@@ -73,7 +73,8 @@ describe('get', () => {
       weight: expect.any(Number),
       lockTime: expect.any(Number),
       vinCount: expect.any(Number),
-      voutCount: expect.any(Number)
+      voutCount: expect.any(Number),
+      totalVOut: expect.any(String)
     })
   })
 

--- a/src/module.api/transaction.controller.e2e.ts
+++ b/src/module.api/transaction.controller.e2e.ts
@@ -74,7 +74,7 @@ describe('get', () => {
       lockTime: expect.any(Number),
       vinCount: expect.any(Number),
       voutCount: expect.any(Number),
-      totalVOut: expect.any(String)
+      totalVoutValue: expect.any(String)
     })
   })
 

--- a/src/module.api/transaction.controller.e2e.ts
+++ b/src/module.api/transaction.controller.e2e.ts
@@ -59,6 +59,7 @@ describe('get', () => {
     const transaction = await controller.get(txid)
     expect(transaction).toStrictEqual({
       id: txid,
+      order: expect.any(Number),
       block: {
         hash: expect.any(String),
         height: expect.any(Number),

--- a/src/module.api/transaction.controller.ts
+++ b/src/module.api/transaction.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, NotFoundException, Param, Query } from '@nestjs/common'
-import { TransactionMapper } from '@src/module.model/transaction'
+import { TransactionMapper, Transaction as ModelTransaction } from '@src/module.model/transaction'
 import { Transaction } from '@whale-api-client/api/transactions'
+
 import { PaginationQuery } from '@src/module.api/_core/api.query'
 import { ApiPagedResponse } from '@src/module.api/_core/api.paged.response'
 import { TransactionVin, TransactionVinMapper } from '@src/module.model/transaction.vin'
@@ -29,7 +30,7 @@ export class TransactionController {
       throw new NotFoundException('transaction not found')
     }
 
-    return transaction
+    return mapTransaction(transaction)
   }
 
   @Get('/:txid/vins')
@@ -48,5 +49,22 @@ export class TransactionController {
     return ApiPagedResponse.of(vout, query.size, vout => {
       return vout.n.toString()
     })
+  }
+}
+
+function mapTransaction (tx: ModelTransaction): Transaction {
+  return {
+    id: tx.id,
+    block: tx.block,
+    txid: tx.txid,
+    hash: tx.hash,
+    version: tx.version,
+    size: tx.size,
+    vSize: tx.vSize,
+    weight: tx.weight,
+    lockTime: tx.lockTime,
+    vinCount: tx.vinCount,
+    voutCount: tx.voutCount,
+    totalVOut: tx.totalVOut
   }
 }

--- a/src/module.api/transaction.controller.ts
+++ b/src/module.api/transaction.controller.ts
@@ -1,7 +1,5 @@
 import { Controller, Get, NotFoundException, Param, Query } from '@nestjs/common'
-import { TransactionMapper, Transaction as ModelTransaction } from '@src/module.model/transaction'
-import { Transaction } from '@whale-api-client/api/transactions'
-
+import { TransactionMapper, Transaction } from '@src/module.model/transaction'
 import { PaginationQuery } from '@src/module.api/_core/api.query'
 import { ApiPagedResponse } from '@src/module.api/_core/api.paged.response'
 import { TransactionVin, TransactionVinMapper } from '@src/module.model/transaction.vin'
@@ -30,7 +28,7 @@ export class TransactionController {
       throw new NotFoundException('transaction not found')
     }
 
-    return mapTransaction(transaction)
+    return transaction
   }
 
   @Get('/:txid/vins')
@@ -49,22 +47,5 @@ export class TransactionController {
     return ApiPagedResponse.of(vout, query.size, vout => {
       return vout.n.toString()
     })
-  }
-}
-
-function mapTransaction (tx: ModelTransaction): Transaction {
-  return {
-    id: tx.id,
-    block: tx.block,
-    txid: tx.txid,
-    hash: tx.hash,
-    version: tx.version,
-    size: tx.size,
-    vSize: tx.vSize,
-    weight: tx.weight,
-    lockTime: tx.lockTime,
-    vinCount: tx.vinCount,
-    voutCount: tx.voutCount,
-    totalVoutValue: tx.totalVoutValue
   }
 }

--- a/src/module.api/transaction.controller.ts
+++ b/src/module.api/transaction.controller.ts
@@ -65,6 +65,6 @@ function mapTransaction (tx: ModelTransaction): Transaction {
     lockTime: tx.lockTime,
     vinCount: tx.vinCount,
     voutCount: tx.voutCount,
-    totalVOut: tx.totalVOut
+    totalVoutValue: tx.totalVoutValue
   }
 }

--- a/src/module.indexer/model/block.ts
+++ b/src/module.indexer/model/block.ts
@@ -9,14 +9,15 @@ export class BlockIndexer extends Indexer {
   }
 
   async index (block: RawBlock): Promise<void> {
-    await this.mapper.put(this.map(block))
+    const reward = block.tx[0].vout[0].value.toFixed(8)
+    await this.mapper.put(this.map(block, reward))
   }
 
   async invalidate (block: RawBlock): Promise<void> {
     await this.mapper.delete(block.hash)
   }
 
-  map (block: RawBlock): Block {
+  map (block: RawBlock, reward: string): Block {
     return {
       id: block.hash,
       hash: block.hash,
@@ -34,7 +35,8 @@ export class BlockIndexer extends Indexer {
       merkleroot: block.merkleroot,
       size: block.size,
       sizeStripped: block.strippedsize,
-      weight: block.weight
+      weight: block.weight,
+      reward: reward
     }
   }
 }

--- a/src/module.indexer/model/transaction.ts
+++ b/src/module.indexer/model/transaction.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@nestjs/common'
 import { defid, Indexer, RawBlock } from '@src/module.indexer/model/_abstract'
 import { Transaction, TransactionMapper } from '@src/module.model/transaction'
+import { HexEncoder } from '@src/module.model/_hex.encoder'
+import BigNumber from 'bignumber.js'
 
 @Injectable()
 export class TransactionIndexer extends Indexer {
@@ -9,8 +11,11 @@ export class TransactionIndexer extends Indexer {
   }
 
   async index (block: RawBlock): Promise<void> {
-    for (const txn of block.tx) {
-      await this.mapper.put(this.map(block, txn))
+    for (const [order, txn] of block.tx.entries()) {
+      const totalVOut = txn.vout.reduce<BigNumber>((prev, vout) => {
+        return prev.plus(vout.value)
+      }, new BigNumber(0))
+      await this.mapper.put(this.map(block, txn, order, totalVOut.toFixed(8)))
     }
   }
 
@@ -20,9 +25,10 @@ export class TransactionIndexer extends Indexer {
     }
   }
 
-  map (block: RawBlock, txn: defid.Transaction): Transaction {
+  map (block: RawBlock, txn: defid.Transaction, order: number, totalVOut: string): Transaction {
     return {
       id: txn.txid,
+      sort: `${block.hash}-${HexEncoder.encodeHeight(order)}`,
       block: {
         hash: block.hash,
         height: block.height,
@@ -37,7 +43,8 @@ export class TransactionIndexer extends Indexer {
       weight: txn.weight,
       lockTime: txn.locktime,
       vinCount: txn.vin.length,
-      voutCount: txn.vout.length
+      voutCount: txn.vout.length,
+      totalVOut: totalVOut
     }
   }
 }

--- a/src/module.indexer/model/transaction.ts
+++ b/src/module.indexer/model/transaction.ts
@@ -44,7 +44,7 @@ export class TransactionIndexer extends Indexer {
       lockTime: txn.locktime,
       vinCount: txn.vin.length,
       voutCount: txn.vout.length,
-      totalVOut: totalVOut
+      totalVoutValue: totalVOut
     }
   }
 }

--- a/src/module.indexer/model/transaction.ts
+++ b/src/module.indexer/model/transaction.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common'
 import { defid, Indexer, RawBlock } from '@src/module.indexer/model/_abstract'
 import { Transaction, TransactionMapper } from '@src/module.model/transaction'
-import { HexEncoder } from '@src/module.model/_hex.encoder'
 import BigNumber from 'bignumber.js'
 
 @Injectable()
@@ -28,7 +27,7 @@ export class TransactionIndexer extends Indexer {
   map (block: RawBlock, txn: defid.Transaction, order: number, totalVOut: string): Transaction {
     return {
       id: txn.txid,
-      sort: `${block.hash}-${HexEncoder.encodeHeight(order)}`,
+      order: order,
       block: {
         hash: block.hash,
         height: block.height,

--- a/src/module.model/block.spec.ts
+++ b/src/module.model/block.spec.ts
@@ -37,7 +37,8 @@ beforeEach(async () => {
       time: 0,
       transactionCount: 0,
       version: 0,
-      weight: 0
+      weight: 0,
+      reward: ''
     })
   }
 

--- a/src/module.model/block.ts
+++ b/src/module.model/block.ts
@@ -73,6 +73,7 @@ export interface Block extends Model {
   masternode: string
   minter: string
   minterBlockCount: number
+  reward: string // ------------| reward string as decimal
 
   stakeModifier: string
   merkleroot: string

--- a/src/module.model/transaction.ts
+++ b/src/module.model/transaction.ts
@@ -5,15 +5,15 @@ import { Database, SortOrder } from '@src/module.database/database'
 const TransactionMapping: ModelMapping<Transaction> = {
   type: 'transaction',
   index: {
-    block_txid: {
-      name: 'transaction_block_txid',
+    block_order: {
+      name: 'transaction_block_order',
       partition: {
         type: 'string',
         key: (b: Transaction) => b.block.hash
       },
       sort: {
-        type: 'string',
-        key: (b: Transaction) => b.sort
+        type: 'number',
+        key: (b: Transaction) => b.order
       }
     }
   }
@@ -24,8 +24,8 @@ export class TransactionMapper {
   public constructor (protected readonly database: Database) {
   }
 
-  async queryByBlockHash (hash: string, limit: number, gt?: string): Promise<Transaction[]> {
-    return await this.database.query(TransactionMapping.index.block_txid, {
+  async queryByBlockHash (hash: string, limit: number, gt?: number): Promise<Transaction[]> {
+    return await this.database.query(TransactionMapping.index.block_order, {
       partitionKey: hash,
       limit: limit,
       order: SortOrder.ASC,
@@ -51,7 +51,7 @@ export class TransactionMapper {
  */
 export interface Transaction extends Model {
   id: string // ----------------| unique id of the transaction, same as the txid
-  sort: string // --------------| blockHash-order
+  order: number // --------------| tx order
 
   block: {
     hash: string

--- a/src/module.model/transaction.ts
+++ b/src/module.model/transaction.ts
@@ -51,7 +51,7 @@ export class TransactionMapper {
  */
 export interface Transaction extends Model {
   id: string // ----------------| unique id of the transaction, same as the txid
-  sort: string // --------------| height-order
+  sort: string // --------------| blockHash-order
 
   block: {
     hash: string
@@ -67,7 +67,7 @@ export interface Transaction extends Model {
   size: number
   vSize: number
   weight: number
-  totalVOut: string
+  totalVoutValue: string
 
   lockTime: number
 

--- a/src/module.model/transaction.ts
+++ b/src/module.model/transaction.ts
@@ -13,7 +13,7 @@ const TransactionMapping: ModelMapping<Transaction> = {
       },
       sort: {
         type: 'string',
-        key: (b: Transaction) => b.txid
+        key: (b: Transaction) => b.sort
       }
     }
   }
@@ -51,6 +51,7 @@ export class TransactionMapper {
  */
 export interface Transaction extends Model {
   id: string // ----------------| unique id of the transaction, same as the txid
+  sort: string // --------------| height-order
 
   block: {
     hash: string
@@ -66,6 +67,7 @@ export interface Transaction extends Model {
   size: number
   vSize: number
   weight: number
+  totalVOut: string
 
   lockTime: number
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

1. `blocks/:id/transactions` is not ordered by the first appearance in the block, currently it's sorted via txid. We need it to be sorted by the first appearance.
2. `/blocks` API `Block` model should include block reward, by checking the first transaction vout in the block.
3. `/transactions` API `Transaction` model should include total UTXO value out, the summing of all `vout` value.

See #383 https://github.com/DeFiCh/whale/issues/383

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #383

#### Additional comments?:
