### PR TITLE
add `vout.script.hex` for `transaction.vin.ts`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16194,7 +16194,9 @@
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.0.tgz",
           "integrity": "sha512-USH2jBb+C/hIpwD2iRjp0pe0k+MvzG0mlSn/FIdCgQhUb9ALPRjt2KIQdfZDS9r0ZIeUAg7gOu9KL0PFqGqr5Q==",
           "dev": true,
-          "requires": {}
+          "requires": {
+            "ajv": "^8.0.0"
+          }
         },
         "json-schema-traverse": {
           "version": "1.0.0",
@@ -18333,7 +18335,9 @@
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.0.2.tgz",
           "integrity": "sha512-Brah4Uo5/U8v76c6euTwtjVFFaVishwnJrQBYpev1JRh4vjA1F4HY3UzQez41YUCszUCXKagG8v6eVRBHV1gkw==",
           "dev": true,
-          "requires": {}
+          "requires": {
+            "ajv": "^8.0.0"
+          }
         },
         "fs-extra": {
           "version": "10.0.0",

--- a/packages/whale-api-client/src/api/transactions.ts
+++ b/packages/whale-api-client/src/api/transactions.ts
@@ -76,6 +76,9 @@ export interface TransactionVin {
     n: number
     value: string
     tokenId?: number
+    script: {
+      hex: string
+    }
   }
   script?: {
     hex: string

--- a/src/module.indexer/model/transaction.vin.ts
+++ b/src/module.indexer/model/transaction.vin.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common'
-import { Indexer, defid, RawBlock } from '@src/module.indexer/model/_abstract'
+import { defid, Indexer, RawBlock } from '@src/module.indexer/model/_abstract'
 import { TransactionVin, TransactionVinMapper } from '@src/module.model/transaction.vin'
 import { TransactionVout } from '@src/module.model/transaction.vout'
 import { HexEncoder } from '@src/module.model/_hex.encoder'
@@ -49,7 +49,10 @@ export class TransactionVinIndexer extends Indexer {
         txid: vout.txid,
         n: vout.n,
         value: vout.value,
-        tokenId: vout.tokenId
+        tokenId: vout.tokenId,
+        script: {
+          hex: vout.script.hex
+        }
       } : undefined,
       script: vin.scriptSig !== undefined ? {
         hex: vin.scriptSig.hex

--- a/src/module.model/transaction.vin.ts
+++ b/src/module.model/transaction.vin.ts
@@ -60,6 +60,9 @@ export interface TransactionVin extends Model {
     n: number
     value: string
     tokenId?: number
+    script: {
+      hex: string
+    }
   }
 
   script?: {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:

Within TransactionVin, added `vout.script.hex` which was missing. This is required to know the previous script that chains to the next vout. No additional test was added because the body of vin wasn't tested (not critical component). 😰 

This is requested by @joeldavidw 