### PR TITLE
fix USD TVL calculation by making it more flexible for FC update

### DIFF
--- a/.idea/dictionaries/fuxing.xml
+++ b/.idea/dictionaries/fuxing.xml
@@ -44,6 +44,7 @@
       <w>dogfooding</w>
       <w>dummypos</w>
       <w>dumpprivkey</w>
+      <w>dusd</w>
       <w>equalverify</w>
       <w>eunos</w>
       <w>fromaltstack</w>

--- a/packages/whale-api-client/__tests__/api/poolpairs.test.ts
+++ b/packages/whale-api-client/__tests__/api/poolpairs.test.ts
@@ -79,13 +79,24 @@ async function setup (): Promise<void> {
     amountB: 431.51288,
     shareAddress: await getNewAddress(container)
   })
+
+  await createToken(container, 'USDC')
+  await createPoolPair(container, 'USDC', 'H')
+  await mintTokens(container, 'USDC')
+  await addPoolLiquidity(container, {
+    tokenA: 'USDC',
+    amountA: 500,
+    tokenB: 'H',
+    amountB: 31.51288,
+    shareAddress: await getNewAddress(container)
+  })
 }
 
 describe('list', () => {
   it('should list', async () => {
     const response: ApiPagedResponse<PoolPairData> = await client.poolpairs.list(30)
 
-    expect(response.length).toStrictEqual(9)
+    expect(response.length).toStrictEqual(10)
     expect(response.hasNext).toStrictEqual(false)
 
     expect(response[1]).toStrictEqual({
@@ -114,7 +125,7 @@ describe('list', () => {
       commission: '0',
       totalLiquidity: {
         token: '122.47448713',
-        usd: '1390.456752'
+        usd: '1390.4567576291117892'
       },
       tradeEnabled: true,
       ownerAddress: expect.any(String),
@@ -161,7 +172,7 @@ describe('list', () => {
 })
 
 describe('get', () => {
-  it('should get', async () => {
+  it('should get 9', async () => {
     const response: PoolPairData = await client.poolpairs.get('9')
 
     expect(response).toStrictEqual({
@@ -190,13 +201,58 @@ describe('get', () => {
       commission: '0',
       totalLiquidity: {
         token: '141.42135623',
-        usd: '926.971168'
+        usd: '926.9711717527411928'
       },
       tradeEnabled: true,
       ownerAddress: expect.any(String),
       priceRatio: {
         ab: '0.5',
         ba: '2'
+      },
+      rewardPct: '0',
+      creation: {
+        tx: expect.any(String),
+        height: expect.any(Number)
+      }
+    })
+  })
+
+  it('should get 20', async () => {
+    const response: PoolPairData = await client.poolpairs.get('20')
+
+    expect(response).toStrictEqual({
+      id: '20',
+      symbol: 'USDC-H',
+      name: 'USDC-H',
+      status: true,
+      tokenA: {
+        id: expect.any(String),
+        symbol: 'USDC',
+        reserve: '500',
+        blockCommission: '0',
+        displaySymbol: 'dUSDC'
+      },
+      tokenB: {
+        id: '8',
+        symbol: 'H',
+        reserve: '31.51288',
+        blockCommission: '0',
+        displaySymbol: 'dH'
+      },
+      apr: {
+        reward: 0,
+        total: 0
+      },
+      commission: '0',
+      totalLiquidity: {
+        token: '125.52465893',
+        usd: '1000'
+      },
+      tradeEnabled: true,
+      ownerAddress: expect.any(String),
+      priceRatio: {
+        ab: '15.86652822',
+        ba: '0.06302576'
       },
       rewardPct: '0',
       creation: {

--- a/packages/whale-api-client/__tests__/api/poolpairs.test.ts
+++ b/packages/whale-api-client/__tests__/api/poolpairs.test.ts
@@ -163,11 +163,12 @@ describe('list', () => {
     expect(next[3].symbol).toStrictEqual('H-DFI')
 
     const last = await client.paginate(next)
-    expect(last.length).toStrictEqual(1)
+    expect(last.length).toStrictEqual(2)
     expect(last.hasNext).toStrictEqual(false)
     expect(last.nextToken).toBeUndefined()
 
     expect(last[0].symbol).toStrictEqual('USDT-DFI')
+    expect(last[1].symbol).toStrictEqual('USDC-H')
   })
 })
 

--- a/packages/whale-api-client/__tests__/api/stats.test.ts
+++ b/packages/whale-api-client/__tests__/api/stats.test.ts
@@ -49,6 +49,16 @@ describe('stats', () => {
       amountB: 431.51288,
       shareAddress: await getNewAddress(container)
     })
+    await createToken(container, 'USDC')
+    await createPoolPair(container, 'USDC', 'DFI')
+    await mintTokens(container, 'USDC')
+    await addPoolLiquidity(container, {
+      tokenA: 'USDC',
+      amountA: 1000,
+      tokenB: 'DFI',
+      amountB: 431.51288,
+      shareAddress: await getNewAddress(container)
+    })
     const height = await container.getBlockCount()
     await container.generate(1)
     await service.waitForIndexedHeight(height)
@@ -66,15 +76,32 @@ describe('stats', () => {
     const data = await client.stats.get()
 
     expect(data).toStrictEqual({
-      count: { blocks: 117, prices: 0, tokens: 7, masternodes: 8 },
-      burned: { address: 0, emission: 7014.88, fee: 3, total: 7017.88 },
-      tvl: { dex: 3853.9423279032194, total: 4039.3365615032194, masternodes: 185.3942336 },
-      price: { usdt: 2.31742792 },
+      count: {
+        blocks: 122,
+        prices: 0,
+        tokens: 9,
+        masternodes: 8
+      },
+      burned: {
+        address: 0,
+        emission: 7323.58,
+        fee: 4,
+        total: 7327.58
+      },
+      tvl: {
+        dex: 5853.942343505482,
+        masternodes: 185.39423435054823,
+        total: 6039.336577856031
+      },
+      price: {
+        usd: 2.317427929381853,
+        usdt: 2.317427929381853
+      },
       masternodes: {
         locked: [
           {
             count: 8,
-            tvl: 185.3942336,
+            tvl: 185.39423435054823,
             weeks: 0
           }
         ]

--- a/packages/whale-api-client/src/api/stats.ts
+++ b/packages/whale-api-client/src/api/stats.ts
@@ -36,10 +36,14 @@ export interface StatsData {
     address: number
   }
   price: {
+    usd: number
+    /**
+     * @deprecated use USD instead of aggregation over multiple pairs
+     */
     usdt: number
   }
   masternodes: {
-    locked: Array<{weeks: number, tvl: number, count: number}>
+    locked: Array<{ weeks: number, tvl: number, count: number }>
   }
   emission: {
     total: number

--- a/src/module.api/poolpair.controller.e2e.ts
+++ b/src/module.api/poolpair.controller.e2e.ts
@@ -114,7 +114,7 @@ describe('list', () => {
       commission: '0',
       totalLiquidity: {
         token: '122.47448713',
-        usd: '1390.456752'
+        usd: '1390.4567576291117892'
       },
       tradeEnabled: true,
       ownerAddress: expect.any(String),
@@ -194,7 +194,7 @@ describe('get', () => {
       commission: '0',
       totalLiquidity: {
         token: '141.42135623',
-        usd: '926.971168'
+        usd: '926.9711717527411928'
       },
       tradeEnabled: true,
       ownerAddress: expect.any(String),


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

- USDT, USDC, DUSD pairs TVL will be calculated with itself now.
- USDT, USDC will be used collectively for USD of DFI calculation instead of just using USDT.