### PR TITLE
`dependabot.yml` allowed defichain deps to be auto updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
       day: 'thursday'
     labels:
       - "kind/dependencies"
-    ignore:
-      - dependency-name: "@defichain/*"
     versioning-strategy: 'increase'
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind dependencies

#### What this PR does / why we need it:

With peer dependencies enabled, we can test how dependabot will auto-update all `@defichain` dependencies together.