### PR TITLE
denormalize loan scheme data

### DIFF
--- a/packages/whale-api-client/__tests__/api/address.vault.test.ts
+++ b/packages/whale-api-client/__tests__/api/address.vault.test.ts
@@ -72,7 +72,11 @@ describe('list', () => {
     result.forEach(e =>
       expect(e).toStrictEqual({
         vaultId: expect.any(String),
-        loanSchemeId: 'default',
+        loanScheme: {
+          id: 'default',
+          interestRate: '2.5',
+          minColRatio: '100'
+        },
         ownerAddress: address,
         state: LoanVaultState.ACTIVE,
         informativeRatio: '-1',

--- a/packages/whale-api-client/__tests__/api/loan.vault.test.ts
+++ b/packages/whale-api-client/__tests__/api/loan.vault.test.ts
@@ -187,7 +187,11 @@ describe('list', () => {
     result.forEach(e =>
       expect(e).toStrictEqual(expect.objectContaining({
         vaultId: expect.any(String),
-        loanSchemeId: expect.any(String),
+        loanScheme: {
+          id: expect.any(String),
+          interestRate: expect.any(String),
+          minColRatio: expect.any(String)
+        },
         ownerAddress: expect.any(String),
         state: expect.any(String)
       }))
@@ -229,7 +233,11 @@ describe('get', () => {
     const vault = await client.loan.getVault(johnEmptyVaultId)
     expect(vault).toStrictEqual({
       vaultId: johnEmptyVaultId,
-      loanSchemeId: 'default',
+      loanScheme: {
+        id: 'default',
+        interestRate: '1',
+        minColRatio: '100'
+      },
       ownerAddress: expect.any(String),
       state: LoanVaultState.ACTIVE,
       informativeRatio: '-1',
@@ -247,7 +255,11 @@ describe('get', () => {
     const vault = await client.loan.getVault(bobDepositedVaultId)
     expect(vault).toStrictEqual({
       vaultId: bobDepositedVaultId,
-      loanSchemeId: 'default',
+      loanScheme: {
+        id: 'default',
+        interestRate: '1',
+        minColRatio: '100'
+      },
       ownerAddress: expect.any(String),
       state: LoanVaultState.ACTIVE,
       informativeRatio: '-1',
@@ -274,7 +286,11 @@ describe('get', () => {
     const vault = await client.loan.getVault(johnLoanedVaultId)
     expect(vault).toStrictEqual({
       vaultId: johnLoanedVaultId,
-      loanSchemeId: 'scheme',
+      loanScheme: {
+        id: 'scheme',
+        interestRate: '1',
+        minColRatio: '110'
+      },
       ownerAddress: expect.any(String),
       state: LoanVaultState.ACTIVE,
       collateralRatio: '16667',
@@ -319,7 +335,11 @@ describe('get', () => {
     const vault = await client.loan.getVault(adamLiquidatedVaultId)
     expect(vault).toStrictEqual({
       vaultId: adamLiquidatedVaultId,
-      loanSchemeId: 'default',
+      loanScheme: {
+        id: 'default',
+        interestRate: '1',
+        minColRatio: '100'
+      },
       ownerAddress: expect.any(String),
       state: LoanVaultState.IN_LIQUIDATION,
       batchCount: 1,

--- a/packages/whale-api-client/src/api/loan.ts
+++ b/packages/whale-api-client/src/api/loan.ts
@@ -114,7 +114,7 @@ export interface LoanToken {
 
 export interface LoanVaultActive {
   vaultId: string
-  loanSchemeId: string
+  loanScheme: LoanScheme
   ownerAddress: string
   state: LoanVaultState.ACTIVE | LoanVaultState.FROZEN | LoanVaultState.MAY_LIQUIDATE | LoanVaultState.UNKNOWN
 
@@ -131,7 +131,7 @@ export interface LoanVaultActive {
 
 export interface LoanVaultLiquidated {
   vaultId: string
-  loanSchemeId: string
+  loanScheme: LoanScheme
   ownerAddress: string
   state: LoanVaultState.IN_LIQUIDATION
 

--- a/src/module.api/cache/defid.cache.ts
+++ b/src/module.api/cache/defid.cache.ts
@@ -4,6 +4,7 @@ import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
 import { TokenInfo, TokenResult } from '@defichain/jellyfish-api-core/dist/category/token'
 import { CachePrefix, GlobalCache } from '@src/module.api/cache/global.cache'
 import { PoolPairInfo } from '@defichain/jellyfish-api-core/dist/category/poolpair'
+import { GetLoanSchemeResult } from '@defichain/jellyfish-api-core/dist/category/loan'
 
 @Injectable()
 export class DeFiDCache extends GlobalCache {
@@ -46,6 +47,14 @@ export class DeFiDCache extends GlobalCache {
 
   private async fetchTokenInfoBySymbol (symbol: string): Promise<TokenResult | undefined> {
     return await this.rpcClient.token.getToken(symbol)
+  }
+
+  async getLoanScheme (id: string): Promise<GetLoanSchemeResult | undefined> {
+    return await this.get<GetLoanSchemeResult>(CachePrefix.LOAN_SCHEME_INFO, id, this.fetchLoanSchemeInfo.bind(this))
+  }
+
+  private async fetchLoanSchemeInfo (id: string): Promise<GetLoanSchemeResult | undefined> {
+    return await this.rpcClient.loan.getLoanScheme(id)
   }
 
   async getPoolPairInfo (id: string): Promise<PoolPairInfo | undefined> {

--- a/src/module.api/cache/global.cache.ts
+++ b/src/module.api/cache/global.cache.ts
@@ -8,7 +8,8 @@ export enum CachePrefix {
   SEMAPHORE = -1,
   TOKEN_INFO = 0,
   POOL_PAIR_INFO = 1,
-  TOKEN_INFO_SYMBOL = 2
+  TOKEN_INFO_SYMBOL = 2,
+  LOAN_SCHEME_INFO = 3
 }
 
 export class GlobalCache {

--- a/src/module.api/loan.vault.controller.e2e.ts
+++ b/src/module.api/loan.vault.controller.e2e.ts
@@ -78,7 +78,11 @@ describe('loan', () => {
     result.data.forEach(e =>
       expect(e).toStrictEqual({
         vaultId: expect.any(String),
-        loanSchemeId: 'default',
+        loanScheme: {
+          id: 'default',
+          interestRate: '1.5',
+          minColRatio: '150'
+        },
         ownerAddress: expect.any(String),
         state: expect.any(String),
         informativeRatio: '-1',
@@ -99,7 +103,11 @@ describe('get', () => {
     const data = await controller.getVault(vaultId1)
     expect(data).toStrictEqual({
       vaultId: vaultId1,
-      loanSchemeId: 'default',
+      loanScheme: {
+        id: 'default',
+        interestRate: '1.5',
+        minColRatio: '150'
+      },
       ownerAddress: address1,
       state: LoanVaultState.ACTIVE,
       informativeRatio: '-1',

--- a/src/module.api/loan.vault.service.ts
+++ b/src/module.api/loan.vault.service.ts
@@ -8,6 +8,7 @@ import {
 } from '@defichain/jellyfish-api-core/dist/category/loan'
 import { ApiPagedResponse } from '@src/module.api/_core/api.paged.response'
 import {
+  LoanScheme,
   LoanVaultActive,
   LoanVaultLiquidated,
   LoanVaultLiquidationBatch,
@@ -65,7 +66,7 @@ export class LoanVaultService {
       const data = details as VaultLiquidation
       return {
         vaultId: data.vaultId,
-        loanSchemeId: data.loanSchemeId,
+        loanScheme: await this.mapLoanScheme(data.loanSchemeId),
         ownerAddress: data.ownerAddress,
         state: LoanVaultState.IN_LIQUIDATION,
         batchCount: data.batchCount,
@@ -78,7 +79,7 @@ export class LoanVaultService {
     const data = details as VaultActive
     return {
       vaultId: data.vaultId,
-      loanSchemeId: data.loanSchemeId,
+      loanScheme: await this.mapLoanScheme(data.loanSchemeId),
       ownerAddress: data.ownerAddress,
       state: mapLoanVaultState(data.state) as any,
 
@@ -131,6 +132,18 @@ export class LoanVaultService {
     })
 
     return await Promise.all(items)
+  }
+
+  private async mapLoanScheme (id: string): Promise<LoanScheme> {
+    const scheme = await this.deFiDCache.getLoanScheme(id)
+    if (scheme === undefined) {
+      throw new ConflictException('unable to find loan scheme')
+    }
+    return {
+      id: scheme.id,
+      minColRatio: scheme.mincolratio.toFixed(),
+      interestRate: scheme.interestrate.toFixed()
+    }
   }
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:

Within LoanVault, loanSchemeId is denormalized to be `loanScheme: {...}` giving you richer information without having to call the API to get them. This is a breaking change.