### PR TITLE
size refactor on core and vaults

### DIFF
--- a/packages/whale-api-client/__tests__/api/blocks.test.ts
+++ b/packages/whale-api-client/__tests__/api/blocks.test.ts
@@ -16,8 +16,8 @@ beforeAll(async () => {
   await container.waitForWalletCoinbaseMaturity()
   await service.start()
 
-  await container.waitForBlockHeight(101)
-  await service.waitForIndexedHeight(101)
+  await container.waitForBlockHeight(201)
+  await service.waitForIndexedHeight(201)
 })
 
 afterAll(async () => {
@@ -66,10 +66,10 @@ describe('list', () => {
     expect(last.hasNext).toStrictEqual(false)
   })
 
-  it('should get paginated list of 100 even if request page size is  more than 100', async () => {
-    const first = await client.blocks.list(150)
+  it('should get paginated list of 200 even if request page size is more than 200', async () => {
+    const first = await client.blocks.list(250)
 
-    expect(first.length).toStrictEqual(100)
+    expect(first.length).toStrictEqual(200)
     expect(first[0]).toStrictEqual(ExpectedBlock)
   })
 

--- a/packages/whale-api-client/__tests__/api/blocks.test.ts
+++ b/packages/whale-api-client/__tests__/api/blocks.test.ts
@@ -51,18 +51,22 @@ const ExpectedBlock = {
 
 describe('list', () => {
   it('should get paginated list of blocks', async () => {
-    const first = await client.blocks.list(35)
+    const first = await client.blocks.list(100)
 
-    expect(first.length).toStrictEqual(35)
+    expect(first.length).toStrictEqual(100)
     expect(first[0]).toStrictEqual(ExpectedBlock)
-    expect(first[0].height).toBeGreaterThanOrEqual(100 - 35)
-    expect(first[34].height).toBeGreaterThanOrEqual(first[0].height - 35)
+    expect(first[0].height).toBeGreaterThanOrEqual(200 - 100)
+    expect(first[34].height).toBeGreaterThanOrEqual(first[0].height - 100)
 
     const second = await client.paginate(first)
-    expect(second.length).toStrictEqual(35)
-    expect(second[0].height).toStrictEqual(first[34].height - 1)
+    expect(second.length).toStrictEqual(100)
+    expect(second[0].height).toStrictEqual(first[99].height - 1)
 
-    const last = await client.paginate(second)
+    const third = await client.paginate(second)
+    expect(third.length).toBeGreaterThanOrEqual(1)
+    expect(third[0].height).toStrictEqual(second[99].height - 1)
+
+    const last = await client.paginate(third)
     expect(last.hasNext).toStrictEqual(false)
   })
 

--- a/src/module.api/_core/api.query.ts
+++ b/src/module.api/_core/api.query.ts
@@ -1,5 +1,5 @@
 import { IsInt, IsOptional, IsString, Min } from 'class-validator'
-import { Type, Transform } from 'class-transformer'
+import { Transform, Type } from 'class-transformer'
 
 /**
  * Pagination query with
@@ -11,8 +11,8 @@ import { Type, Transform } from 'class-transformer'
 export class PaginationQuery {
   @IsOptional()
   @IsInt()
-  @Transform(({ value }) => value > 100 ? 100 : value)
-  @Min(0)
+  @Transform(({ value }) => value > 200 ? 200 : value)
+  @Min(1)
   @Type(() => Number)
   size: number = 30
 

--- a/src/module.api/loan.vault.service.ts
+++ b/src/module.api/loan.vault.service.ts
@@ -29,10 +29,12 @@ export class LoanVaultService {
   }
 
   async list (query: PaginationQuery, address?: string): Promise<ApiPagedResponse<LoanVaultActive | LoanVaultLiquidated>> {
+    const next = query.next !== undefined ? String(query.next) : undefined
+    const size = query.size > 30 ? 30 : query.size
     const pagination: VaultPagination = {
-      start: query.next !== undefined ? String(query.next) : undefined,
+      start: next,
       // including_start: query.next === undefined,
-      limit: query.size > 10 ? 10 : query.size // limit size to 10 for vault querying
+      limit: size
     }
 
     const list: Array<VaultActive | VaultLiquidation> = await this.client.loan
@@ -42,7 +44,7 @@ export class LoanVaultService {
     })
 
     const items = await Promise.all(vaults)
-    return ApiPagedResponse.of(items, query.size, item => {
+    return ApiPagedResponse.of(items, size, item => {
       return item.vaultId
     })
   }


### PR DESCRIPTION


<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:


- size is checked to make sure it's not 0 due to upstream no checking
- /loans/vaults and /address/vaults allow size to 30 from 10 due changed on core side