### PR TITLE
include activePrice in /loans/tokens and /loans/collaterals

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "prepare": "husky install",
     "standard": "ts-standard --fix",
+    "lint": "ts-standard --fix",
     "prebuild": "rimraf dist",
     "build": "nest build",
     "start": "nest start",

--- a/packages/whale-api-client/__tests__/api/loan.collateral.test.ts
+++ b/packages/whale-api-client/__tests__/api/loan.collateral.test.ts
@@ -1,101 +1,147 @@
 import { StubWhaleApiClient } from '../stub.client'
 import { StubService } from '../stub.service'
-import { WhaleApiClient, WhaleApiException } from '../../src'
+import { WhaleApiException } from '../../src'
 import BigNumber from 'bignumber.js'
 import { Testing } from '@defichain/jellyfish-testing'
-import { LoanMasterNodeRegTestContainer } from '@defichain/testcontainers'
+import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
 
-let container: LoanMasterNodeRegTestContainer
-let service: StubService
-let client: WhaleApiClient
-
+const container = new MasterNodeRegTestContainer()
+const service = new StubService(container)
+const client = new StubWhaleApiClient(service)
 let collateralTokenId1: string
 
-beforeAll(async () => {
-  container = new LoanMasterNodeRegTestContainer()
-  service = new StubService(container)
-  client = new StubWhaleApiClient(service)
+/* eslint-disable no-lone-blocks */
 
+beforeAll(async () => {
   await container.start()
   await container.waitForWalletCoinbaseMaturity()
   await service.start()
 
   const testing = Testing.create(container)
 
-  await testing.token.create({ symbol: 'AAPL' })
-  await testing.generate(1)
+  {
+    await testing.token.create({ symbol: 'AAPL' })
+    await testing.generate(1)
 
-  await testing.token.create({ symbol: 'TSLA' })
-  await testing.generate(1)
+    await testing.token.create({ symbol: 'TSLA' })
+    await testing.generate(1)
 
-  await testing.token.create({ symbol: 'MSFT' })
-  await testing.generate(1)
+    await testing.token.create({ symbol: 'MSFT' })
+    await testing.generate(1)
 
-  await testing.token.create({ symbol: 'FB' })
-  await testing.generate(1)
+    await testing.token.create({ symbol: 'FB' })
+    await testing.generate(1)
+  }
 
-  const oracleId = await testing.rpc.oracle.appointOracle(await container.getNewAddress(),
-    [
+  {
+    const oracleId = await testing.rpc.oracle.appointOracle(await container.getNewAddress(),
+      [
+        { token: 'AAPL', currency: 'USD' },
+        { token: 'TSLA', currency: 'USD' },
+        { token: 'MSFT', currency: 'USD' },
+        { token: 'FB', currency: 'USD' }
+      ], { weightage: 1 })
+    await testing.generate(1)
+
+    await testing.rpc.oracle.setOracleData(oracleId, Math.floor(new Date().getTime() / 1000), {
+      prices: [{
+        tokenAmount: '1.5@AAPL',
+        currency: 'USD'
+      }]
+    })
+    await testing.rpc.oracle.setOracleData(oracleId, Math.floor(new Date().getTime() / 1000), {
+      prices: [{
+        tokenAmount: '2.5@TSLA',
+        currency: 'USD'
+      }]
+    })
+    await testing.rpc.oracle.setOracleData(oracleId, Math.floor(new Date().getTime() / 1000), {
+      prices: [{
+        tokenAmount: '3.5@MSFT',
+        currency: 'USD'
+      }]
+    })
+    await testing.rpc.oracle.setOracleData(oracleId, Math.floor(new Date().getTime() / 1000), {
+      prices: [{
+        tokenAmount: '4.5@FB',
+        currency: 'USD'
+      }]
+    })
+    await testing.generate(1)
+  }
+
+  {
+    const oracleId = await testing.rpc.oracle.appointOracle(await testing.generateAddress(), [
       { token: 'AAPL', currency: 'USD' },
       { token: 'TSLA', currency: 'USD' },
       { token: 'MSFT', currency: 'USD' },
       { token: 'FB', currency: 'USD' }
     ], { weightage: 1 })
-  await testing.generate(1)
+    await testing.generate(1)
 
-  await testing.rpc.oracle.setOracleData(oracleId, Math.floor(new Date().getTime() / 1000), {
-    prices: [{
-      tokenAmount: '1.5@AAPL',
-      currency: 'USD'
-    }]
-  })
-  await testing.rpc.oracle.setOracleData(oracleId, Math.floor(new Date().getTime() / 1000), {
-    prices: [{
-      tokenAmount: '2.5@TSLA',
-      currency: 'USD'
-    }]
-  })
-  await testing.rpc.oracle.setOracleData(oracleId, Math.floor(new Date().getTime() / 1000), {
-    prices: [{
-      tokenAmount: '3.5@MSFT',
-      currency: 'USD'
-    }]
-  })
-  await testing.rpc.oracle.setOracleData(oracleId, Math.floor(new Date().getTime() / 1000), {
-    prices: [{
-      tokenAmount: '4.5@FB',
-      currency: 'USD'
-    }]
-  })
-  await testing.generate(1)
+    await testing.rpc.oracle.setOracleData(oracleId, Math.floor(new Date().getTime() / 1000), {
+      prices: [{
+        tokenAmount: '2@AAPL',
+        currency: 'USD'
+      }]
+    })
+    await testing.rpc.oracle.setOracleData(oracleId, Math.floor(new Date().getTime() / 1000), {
+      prices: [{
+        tokenAmount: '2@TSLA',
+        currency: 'USD'
+      }]
+    })
+    await testing.rpc.oracle.setOracleData(oracleId, Math.floor(new Date().getTime() / 1000), {
+      prices: [{
+        tokenAmount: '2@MSFT',
+        currency: 'USD'
+      }]
+    })
+    await testing.rpc.oracle.setOracleData(oracleId, Math.floor(new Date().getTime() / 1000), {
+      prices: [{
+        tokenAmount: '2@FB',
+        currency: 'USD'
+      }]
+    })
+    await testing.generate(1)
+  }
 
-  collateralTokenId1 = await testing.rpc.loan.setCollateralToken({
-    token: 'AAPL',
-    factor: new BigNumber(0.1),
-    fixedIntervalPriceId: 'AAPL/USD'
-  })
-  await testing.generate(1)
+  {
+    collateralTokenId1 = await testing.rpc.loan.setCollateralToken({
+      token: 'AAPL',
+      factor: new BigNumber(0.1),
+      fixedIntervalPriceId: 'AAPL/USD'
+    })
+    await testing.generate(1)
 
-  await testing.rpc.loan.setCollateralToken({
-    token: 'TSLA',
-    factor: new BigNumber(0.2),
-    fixedIntervalPriceId: 'TSLA/USD'
-  })
-  await testing.generate(1)
+    await testing.rpc.loan.setCollateralToken({
+      token: 'TSLA',
+      factor: new BigNumber(0.2),
+      fixedIntervalPriceId: 'TSLA/USD'
+    })
+    await testing.generate(1)
 
-  await testing.rpc.loan.setCollateralToken({
-    token: 'MSFT',
-    factor: new BigNumber(0.3),
-    fixedIntervalPriceId: 'MSFT/USD'
-  })
-  await testing.generate(1)
+    await testing.rpc.loan.setCollateralToken({
+      token: 'MSFT',
+      factor: new BigNumber(0.3),
+      fixedIntervalPriceId: 'MSFT/USD'
+    })
+    await testing.generate(1)
 
-  await testing.rpc.loan.setCollateralToken({
-    token: 'FB',
-    factor: new BigNumber(0.4),
-    fixedIntervalPriceId: 'FB/USD'
-  })
-  await testing.generate(1)
+    await testing.rpc.loan.setCollateralToken({
+      token: 'FB',
+      factor: new BigNumber(0.4),
+      fixedIntervalPriceId: 'FB/USD'
+    })
+    await testing.generate(1)
+  }
+
+  {
+    await testing.generate(6)
+    const height = await container.getBlockCount()
+    await container.generate(1)
+    await service.waitForIndexedHeight(height)
+  }
 })
 
 afterAll(async () => {
@@ -114,9 +160,6 @@ describe('list', () => {
     // Not deterministic ordering due to use of id
     expect(result[0]).toStrictEqual({
       tokenId: expect.any(String),
-      priceFeedId: expect.any(String),
-      factor: expect.any(String),
-      activateAfterBlock: expect.any(Number),
       token: {
         collateralAddress: expect.any(String),
         creation: {
@@ -140,6 +183,37 @@ describe('list', () => {
         symbol: expect.any(String),
         symbolKey: expect.any(String),
         tradeable: true
+      },
+      factor: expect.any(String),
+      activateAfterBlock: expect.any(Number),
+      fixedIntervalPriceId: expect.any(String),
+      activePrice: {
+        active: {
+          amount: expect.any(String),
+          oracles: {
+            active: 2,
+            total: 2
+          },
+          weightage: 2
+        },
+        block: {
+          hash: expect.any(String),
+          height: expect.any(Number),
+          medianTime: expect.any(Number),
+          time: expect.any(Number)
+        },
+        id: expect.any(String),
+        isLive: true,
+        key: expect.any(String),
+        next: {
+          amount: expect.any(String),
+          oracles: {
+            active: 2,
+            total: 2
+          },
+          weightage: 2
+        },
+        sort: expect.any(String)
       }
     })
   })
@@ -171,8 +245,6 @@ describe('get', () => {
     expect(data).toStrictEqual({
       tokenId: collateralTokenId1,
       factor: '0.1',
-      priceFeedId: 'AAPL/USD',
-      activateAfterBlock: 108,
       token: {
         collateralAddress: expect.any(String),
         creation: {
@@ -196,6 +268,36 @@ describe('get', () => {
         symbol: 'AAPL',
         symbolKey: expect.any(String),
         tradeable: true
+      },
+      activateAfterBlock: 110,
+      fixedIntervalPriceId: 'AAPL/USD',
+      activePrice: {
+        active: {
+          amount: '1.75000000',
+          oracles: {
+            active: 2,
+            total: 2
+          },
+          weightage: 2
+        },
+        block: {
+          hash: expect.any(String),
+          height: expect.any(Number),
+          medianTime: expect.any(Number),
+          time: expect.any(Number)
+        },
+        id: expect.any(String),
+        isLive: true,
+        key: 'AAPL-USD',
+        next: {
+          amount: '1.75000000',
+          oracles: {
+            active: 2,
+            total: 2
+          },
+          weightage: 2
+        },
+        sort: expect.any(String)
       }
     })
   })

--- a/packages/whale-api-client/__tests__/api/loan.collateral.test.ts
+++ b/packages/whale-api-client/__tests__/api/loan.collateral.test.ts
@@ -137,7 +137,7 @@ beforeAll(async () => {
   }
 
   {
-    await testing.generate(6)
+    await testing.generate(12)
     const height = await container.getBlockCount()
     await container.generate(1)
     await service.waitForIndexedHeight(height)

--- a/packages/whale-api-client/__tests__/api/loan.token.test.ts
+++ b/packages/whale-api-client/__tests__/api/loan.token.test.ts
@@ -1,90 +1,135 @@
 import { StubWhaleApiClient } from '../stub.client'
 import { StubService } from '../stub.service'
-import { WhaleApiClient, WhaleApiException } from '../../src'
+import { WhaleApiException } from '../../src'
 import BigNumber from 'bignumber.js'
 import { Testing } from '@defichain/jellyfish-testing'
-import { LoanMasterNodeRegTestContainer } from '@defichain/testcontainers'
+import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
 
-let container: LoanMasterNodeRegTestContainer
-let service: StubService
-let client: WhaleApiClient
+const container = new MasterNodeRegTestContainer()
+const service = new StubService(container)
+const client = new StubWhaleApiClient(service)
+
+/* eslint-disable no-lone-blocks */
 
 beforeAll(async () => {
-  container = new LoanMasterNodeRegTestContainer()
-  service = new StubService(container)
-  client = new StubWhaleApiClient(service)
-
   await container.start()
   await container.waitForWalletCoinbaseMaturity()
   await service.start()
 
   const testing = Testing.create(container)
 
-  const oracleId = await testing.container.call('appointoracle', [await testing.generateAddress(), [
-    { token: 'AAPL', currency: 'USD' },
-    { token: 'TSLA', currency: 'USD' },
-    { token: 'MSFT', currency: 'USD' },
-    { token: 'FB', currency: 'USD' }
-  ], 1])
-  await testing.generate(1)
+  {
+    const oracleId = await testing.rpc.oracle.appointOracle(await testing.generateAddress(), [
+      { token: 'AAPL', currency: 'USD' },
+      { token: 'TSLA', currency: 'USD' },
+      { token: 'MSFT', currency: 'USD' },
+      { token: 'FB', currency: 'USD' }
+    ], { weightage: 1 })
+    await testing.generate(1)
 
-  await testing.rpc.oracle.setOracleData(oracleId, Math.floor(new Date().getTime() / 1000), {
-    prices: [{
-      tokenAmount: '1.5@AAPL',
-      currency: 'USD'
-    }]
-  })
-  await testing.rpc.oracle.setOracleData(oracleId, Math.floor(new Date().getTime() / 1000), {
-    prices: [{
-      tokenAmount: '2.5@TSLA',
-      currency: 'USD'
-    }]
-  })
-  await testing.rpc.oracle.setOracleData(oracleId, Math.floor(new Date().getTime() / 1000), {
-    prices: [{
-      tokenAmount: '3.5@MSFT',
-      currency: 'USD'
-    }]
-  })
-  await testing.rpc.oracle.setOracleData(oracleId, Math.floor(new Date().getTime() / 1000), {
-    prices: [{
-      tokenAmount: '4.5@FB',
-      currency: 'USD'
-    }]
-  })
-  await testing.generate(1)
+    await testing.rpc.oracle.setOracleData(oracleId, Math.floor(new Date().getTime() / 1000), {
+      prices: [{
+        tokenAmount: '1.5@AAPL',
+        currency: 'USD'
+      }]
+    })
+    await testing.rpc.oracle.setOracleData(oracleId, Math.floor(new Date().getTime() / 1000), {
+      prices: [{
+        tokenAmount: '2.5@TSLA',
+        currency: 'USD'
+      }]
+    })
+    await testing.rpc.oracle.setOracleData(oracleId, Math.floor(new Date().getTime() / 1000), {
+      prices: [{
+        tokenAmount: '3.5@MSFT',
+        currency: 'USD'
+      }]
+    })
+    await testing.rpc.oracle.setOracleData(oracleId, Math.floor(new Date().getTime() / 1000), {
+      prices: [{
+        tokenAmount: '4.5@FB',
+        currency: 'USD'
+      }]
+    })
+    await testing.generate(1)
+  }
 
-  await testing.container.call('setloantoken', [{
-    symbol: 'AAPL',
-    fixedIntervalPriceId: 'AAPL/USD',
-    mintable: false,
-    interest: new BigNumber(0.01)
-  }])
-  await testing.generate(1)
+  {
+    const oracleId = await testing.rpc.oracle.appointOracle(await testing.generateAddress(), [
+      { token: 'AAPL', currency: 'USD' },
+      { token: 'TSLA', currency: 'USD' },
+      { token: 'MSFT', currency: 'USD' },
+      { token: 'FB', currency: 'USD' }
+    ], { weightage: 1 })
+    await testing.generate(1)
 
-  await testing.container.call('setloantoken', [{
-    symbol: 'TSLA',
-    fixedIntervalPriceId: 'TSLA/USD',
-    mintable: false,
-    interest: new BigNumber(0.02)
-  }])
-  await testing.generate(1)
+    await testing.rpc.oracle.setOracleData(oracleId, Math.floor(new Date().getTime() / 1000), {
+      prices: [{
+        tokenAmount: '2@AAPL',
+        currency: 'USD'
+      }]
+    })
+    await testing.rpc.oracle.setOracleData(oracleId, Math.floor(new Date().getTime() / 1000), {
+      prices: [{
+        tokenAmount: '2@TSLA',
+        currency: 'USD'
+      }]
+    })
+    await testing.rpc.oracle.setOracleData(oracleId, Math.floor(new Date().getTime() / 1000), {
+      prices: [{
+        tokenAmount: '2@MSFT',
+        currency: 'USD'
+      }]
+    })
+    await testing.rpc.oracle.setOracleData(oracleId, Math.floor(new Date().getTime() / 1000), {
+      prices: [{
+        tokenAmount: '2@FB',
+        currency: 'USD'
+      }]
+    })
+    await testing.generate(1)
+  }
 
-  await testing.container.call('setloantoken', [{
-    symbol: 'MSFT',
-    fixedIntervalPriceId: 'MSFT/USD',
-    mintable: false,
-    interest: new BigNumber(0.03)
-  }])
-  await testing.generate(1)
+  {
+    await testing.rpc.loan.setLoanToken({
+      symbol: 'AAPL',
+      fixedIntervalPriceId: 'AAPL/USD',
+      mintable: false,
+      interest: new BigNumber(0.01)
+    })
+    await testing.generate(1)
 
-  await testing.container.call('setloantoken', [{
-    symbol: 'FB',
-    fixedIntervalPriceId: 'FB/USD',
-    mintable: false,
-    interest: new BigNumber(0.04)
-  }])
-  await testing.generate(1)
+    await testing.rpc.loan.setLoanToken({
+      symbol: 'TSLA',
+      fixedIntervalPriceId: 'TSLA/USD',
+      mintable: false,
+      interest: new BigNumber(0.02)
+    })
+    await testing.generate(1)
+
+    await testing.rpc.loan.setLoanToken({
+      symbol: 'MSFT',
+      fixedIntervalPriceId: 'MSFT/USD',
+      mintable: false,
+      interest: new BigNumber(0.03)
+    })
+    await testing.generate(1)
+
+    await testing.rpc.loan.setLoanToken({
+      symbol: 'FB',
+      fixedIntervalPriceId: 'FB/USD',
+      mintable: false,
+      interest: new BigNumber(0.04)
+    })
+    await testing.generate(1)
+  }
+
+  {
+    await testing.generate(6)
+    const height = await container.getBlockCount()
+    await container.generate(1)
+    await service.waitForIndexedHeight(height)
+  }
 })
 
 afterAll(async () => {
@@ -126,6 +171,34 @@ describe('list', () => {
         symbol: expect.any(String),
         symbolKey: expect.any(String),
         tradeable: true
+      },
+      activePrice: {
+        active: {
+          amount: expect.any(String),
+          oracles: {
+            active: 2,
+            total: 2
+          },
+          weightage: 2
+        },
+        block: {
+          hash: expect.any(String),
+          height: expect.any(Number),
+          medianTime: expect.any(Number),
+          time: expect.any(Number)
+        },
+        id: expect.any(String),
+        isLive: true,
+        key: expect.any(String),
+        next: {
+          amount: expect.any(String),
+          oracles: {
+            active: 2,
+            total: 2
+          },
+          weightage: 2
+        },
+        sort: expect.any(String)
       }
     })
 
@@ -185,6 +258,34 @@ describe('get', () => {
         symbol: 'AAPL',
         symbolKey: 'AAPL',
         tradeable: true
+      },
+      activePrice: {
+        active: {
+          amount: '1.75000000',
+          oracles: {
+            active: 2,
+            total: 2
+          },
+          weightage: 2
+        },
+        block: {
+          hash: expect.any(String),
+          height: expect.any(Number),
+          medianTime: expect.any(Number),
+          time: expect.any(Number)
+        },
+        id: expect.any(String),
+        isLive: true,
+        key: 'AAPL-USD',
+        next: {
+          amount: '1.75000000',
+          oracles: {
+            active: 2,
+            total: 2
+          },
+          weightage: 2
+        },
+        sort: expect.any(String)
       }
     })
   })

--- a/packages/whale-api-client/__tests__/api/loan.token.test.ts
+++ b/packages/whale-api-client/__tests__/api/loan.token.test.ts
@@ -125,7 +125,7 @@ beforeAll(async () => {
   }
 
   {
-    await testing.generate(6)
+    await testing.generate(12)
     const height = await container.getBlockCount()
     await container.generate(1)
     await service.waitForIndexedHeight(height)

--- a/packages/whale-api-client/__tests__/api/prices.test.ts
+++ b/packages/whale-api-client/__tests__/api/prices.test.ts
@@ -324,20 +324,14 @@ describe('pricefeed with interval', () => {
 })
 
 describe('active price', () => {
-  let container: MasterNodeRegTestContainer
-  let testing: Testing
-  let service: StubService
+  const container = new MasterNodeRegTestContainer()
+  const testing = Testing.create(container)
+  const service = new StubService(container)
+  const apiClient = new StubWhaleApiClient(service)
   let client: JsonRpcClient
-  let apiClient: WhaleApiClient
 
   beforeEach(async () => {
-    container = new MasterNodeRegTestContainer()
-    testing = Testing.create(container)
-    service = new StubService(container)
-    apiClient = new StubWhaleApiClient(service)
-
     await container.start()
-    await container.waitForReady()
     await container.waitForWalletCoinbaseMaturity()
     await service.start()
 
@@ -484,9 +478,7 @@ describe('active price', () => {
     for (let i = 0; i < 2; i++) {
       oracles.push(await client.oracle.appointOracle(address, [
         { token: 'S1', currency: 'USD' }
-      ], {
-        weightage: 1
-      }))
+      ], { weightage: 1 }))
       await container.generate(1)
     }
 

--- a/packages/whale-api-client/src/api/loan.ts
+++ b/packages/whale-api-client/src/api/loan.ts
@@ -1,6 +1,7 @@
 import { WhaleApiClient } from '../whale.api.client'
 import { ApiPagedResponse } from '../whale.api.response'
 import { TokenData } from './tokens'
+import { ActivePrice } from './prices'
 
 export class Loan {
   constructor (private readonly client: WhaleApiClient) {
@@ -101,8 +102,9 @@ export interface CollateralToken {
   tokenId: string
   token: TokenData
   factor: string
-  priceFeedId: string
   activateAfterBlock: number
+  fixedIntervalPriceId: string
+  activePrice?: ActivePrice
 }
 
 export interface LoanToken {
@@ -110,6 +112,7 @@ export interface LoanToken {
   token: TokenData
   interest: string
   fixedIntervalPriceId: string
+  activePrice?: ActivePrice
 }
 
 export interface LoanVaultActive {

--- a/src/module.api/loan.collateral.controller.e2e.ts
+++ b/src/module.api/loan.collateral.controller.e2e.ts
@@ -107,7 +107,7 @@ describe('list', () => {
     expect(result.data.length).toStrictEqual(4)
     expect(result.data[0]).toStrictEqual({
       tokenId: expect.any(String),
-      priceFeedId: expect.any(String),
+      fixedIntervalPriceId: expect.any(String),
       factor: expect.any(String),
       activateAfterBlock: expect.any(Number),
       token: {
@@ -133,7 +133,8 @@ describe('list', () => {
         symbol: expect.any(String),
         symbolKey: expect.any(String),
         tradeable: true
-      }
+      },
+      activePrice: undefined
     })
   })
 
@@ -174,7 +175,7 @@ describe('get', () => {
     expect(data).toStrictEqual(
       {
         tokenId: collateralTokenId1,
-        priceFeedId: 'AAPL/USD',
+        fixedIntervalPriceId: 'AAPL/USD',
         factor: '0.1',
         activateAfterBlock: 108,
         token: {
@@ -200,7 +201,8 @@ describe('get', () => {
           symbol: 'AAPL',
           symbolKey: expect.any(String),
           tradeable: true
-        }
+        },
+        activePrice: undefined
       }
     )
   })

--- a/src/module.api/loan.token.controller.e2e.ts
+++ b/src/module.api/loan.token.controller.e2e.ts
@@ -101,7 +101,8 @@ describe('list', () => {
         symbol: expect.any(String),
         symbolKey: expect.any(String),
         tradeable: true
-      }
+      },
+      activePrice: undefined
     })
 
     expect(result.data[1].tokenId.length).toStrictEqual(64)
@@ -170,7 +171,8 @@ describe('get', () => {
         symbol: 'AAPL',
         symbolKey: 'AAPL',
         tradeable: true
-      }
+      },
+      activePrice: undefined
     })
   })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:

Instead of getting the active price individually with `/prices` endpoint, this PR included the ActivePrice for all `LoanToken` and `LoanCollateral` operations.

> `ActivePrice` is fetched from Whale indexed database, this index is different from DeFiCh/ain, it index on its own spin loop cycle. `ActivePrice` can be undefined.