### PR TITLE
add ActivePrice to LoanTokenAmount for convenience

### DIFF
--- a/packages/whale-api-client/__tests__/api/loan.vault.test.ts
+++ b/packages/whale-api-client/__tests__/api/loan.vault.test.ts
@@ -47,7 +47,7 @@ beforeAll(async () => {
   }
 
   let oracleId: string
-  { // Oracle
+  { // Oracle 1
     const oracleAddress = await testing.generateAddress()
     const priceFeeds = [
       { token: 'DFI', currency: 'USD' },
@@ -56,6 +56,32 @@ beforeAll(async () => {
       { token: 'GOOGL', currency: 'USD' }
     ]
     oracleId = await testing.rpc.oracle.appointOracle(oracleAddress, priceFeeds, { weightage: 1 })
+    await testing.generate(1)
+
+    const timestamp = Math.floor(new Date().getTime() / 1000)
+    await testing.rpc.oracle.setOracleData(oracleId, timestamp, {
+      prices: [{ tokenAmount: '1@DFI', currency: 'USD' }]
+    })
+    await testing.rpc.oracle.setOracleData(oracleId, timestamp, {
+      prices: [{ tokenAmount: '2@TSLA', currency: 'USD' }]
+    })
+    await testing.rpc.oracle.setOracleData(oracleId, timestamp, {
+      prices: [{ tokenAmount: '2@AAPL', currency: 'USD' }]
+    })
+    await testing.rpc.oracle.setOracleData(oracleId, timestamp, {
+      prices: [{ tokenAmount: '4@GOOGL', currency: 'USD' }]
+    })
+    await testing.generate(1)
+  }
+
+  { // Oracle 2
+    const priceFeeds = [
+      { token: 'DFI', currency: 'USD' },
+      { token: 'TSLA', currency: 'USD' },
+      { token: 'AAPL', currency: 'USD' },
+      { token: 'GOOGL', currency: 'USD' }
+    ]
+    const oracleId = await testing.rpc.oracle.appointOracle(await testing.generateAddress(), priceFeeds, { weightage: 1 })
     await testing.generate(1)
 
     const timestamp = Math.floor(new Date().getTime() / 1000)
@@ -274,7 +300,16 @@ describe('get', () => {
           id: '0',
           name: 'Default Defi token',
           symbol: 'DFI',
-          symbolKey: 'DFI'
+          symbolKey: 'DFI',
+          activePrice: {
+            active: expect.any(Object),
+            block: expect.any(Object),
+            id: expect.any(String),
+            isLive: expect.any(Boolean),
+            key: 'DFI-USD',
+            next: expect.any(Object),
+            sort: expect.any(String)
+          }
         }
       ],
       loanAmounts: [],
@@ -305,7 +340,16 @@ describe('get', () => {
           id: '0',
           name: 'Default Defi token',
           symbol: 'DFI',
-          symbolKey: 'DFI'
+          symbolKey: 'DFI',
+          activePrice: {
+            active: expect.any(Object),
+            block: expect.any(Object),
+            id: expect.any(String),
+            isLive: expect.any(Boolean),
+            key: 'DFI-USD',
+            next: expect.any(Object),
+            sort: expect.any(String)
+          }
         }
       ],
       loanAmounts: [
@@ -315,7 +359,16 @@ describe('get', () => {
           id: '1',
           name: '',
           symbol: 'TSLA',
-          symbolKey: 'TSLA'
+          symbolKey: 'TSLA',
+          activePrice: {
+            active: expect.any(Object),
+            block: expect.any(Object),
+            id: expect.any(String),
+            isLive: expect.any(Boolean),
+            key: 'TSLA-USD',
+            next: expect.any(Object),
+            sort: expect.any(String)
+          }
         }
       ],
       interestAmounts: [
@@ -325,7 +378,16 @@ describe('get', () => {
           id: '1',
           name: '',
           symbol: 'TSLA',
-          symbolKey: 'TSLA'
+          symbolKey: 'TSLA',
+          activePrice: {
+            active: expect.any(Object),
+            block: expect.any(Object),
+            id: expect.any(String),
+            isLive: expect.any(Boolean),
+            key: 'TSLA-USD',
+            next: expect.any(Object),
+            sort: expect.any(String)
+          }
         }
       ]
     })
@@ -355,16 +417,34 @@ describe('get', () => {
               id: '0',
               name: 'Default Defi token',
               symbol: 'DFI',
-              symbolKey: 'DFI'
+              symbolKey: 'DFI',
+              activePrice: {
+                active: expect.any(Object),
+                block: expect.any(Object),
+                id: expect.any(String),
+                isLive: expect.any(Boolean),
+                key: 'DFI-USD',
+                next: expect.any(Object),
+                sort: expect.any(String)
+              }
             }
           ],
           loan: {
-            amount: '30.00005130',
+            amount: expect.any(String),
             displaySymbol: 'dAAPL',
             id: '2',
             name: '',
             symbol: 'AAPL',
-            symbolKey: 'AAPL'
+            symbolKey: 'AAPL',
+            activePrice: {
+              active: expect.any(Object),
+              block: expect.any(Object),
+              id: expect.any(String),
+              isLive: expect.any(Boolean),
+              key: 'AAPL-USD',
+              next: expect.any(Object),
+              sort: expect.any(String)
+            }
           }
         }
       ]

--- a/packages/whale-api-client/__tests__/api/loan.vault.test.ts
+++ b/packages/whale-api-client/__tests__/api/loan.vault.test.ts
@@ -196,6 +196,11 @@ beforeAll(async () => {
     // Wait for 12 blocks which are equivalent to 2 hours (1 block = 10 minutes in regtest) in order to liquidate the vault
     await testing.generate(12)
   }
+
+  {
+    const height = await container.getBlockCount()
+    await service.waitForIndexedHeight(height - 1)
+  }
 })
 
 afterAll(async () => {

--- a/packages/whale-api-client/__tests__/api/prices.test.ts
+++ b/packages/whale-api-client/__tests__/api/prices.test.ts
@@ -133,6 +133,7 @@ describe('oracles', () => {
     const height = await container.getBlockCount()
     await container.generate(1)
     await service.waitForIndexedHeight(height)
+    await new Promise((resolve) => setTimeout(resolve, 500))
   })
 
   it('should list', async () => {
@@ -284,9 +285,12 @@ describe('pricefeed with interval', () => {
       await container.generate(1)
     }
 
-    const height = await container.getBlockCount()
-    await container.generate(1)
-    await service.waitForIndexedHeight(height)
+    {
+      const height = await container.getBlockCount()
+      await container.generate(1)
+      await service.waitForIndexedHeight(height)
+      await new Promise((resolve) => setTimeout(resolve, 500))
+    }
 
     const noInterval = await apiClient.prices.getFeed('S1', 'USD', 60)
     expect(noInterval.length).toStrictEqual(60)
@@ -368,6 +372,7 @@ describe('active price', () => {
       const height = await container.getBlockCount()
       await container.generate(1)
       await service.waitForIndexedHeight(height)
+      await new Promise((resolve) => setTimeout(resolve, 500))
     }
 
     const beforeActivePrice = await apiClient.prices.getFeedActive('S1', 'USD', 1)
@@ -408,6 +413,7 @@ describe('active price', () => {
       const height = await container.getBlockCount()
       await container.generate(1)
       await service.waitForIndexedHeight(height)
+      await new Promise((resolve) => setTimeout(resolve, 500))
     }
 
     const activePrice = await apiClient.prices.getFeedActive('S1', 'USD', 1)
@@ -445,6 +451,7 @@ describe('active price', () => {
       const height = await container.getBlockCount()
       await container.generate(1)
       await service.waitForIndexedHeight(height)
+      await new Promise((resolve) => setTimeout(resolve, 500))
     }
 
     const nextActivePrice = await apiClient.prices.getFeedActive('S1', 'USD', 1)
@@ -494,6 +501,7 @@ describe('active price', () => {
       const height = await container.getBlockCount()
       await container.generate(1)
       await service.waitForIndexedHeight(height)
+      await new Promise((resolve) => setTimeout(resolve, 500))
     }
 
     const beforeActivePrice = await apiClient.prices.getFeedActive('S1', 'USD', 1)
@@ -532,10 +540,12 @@ describe('active price', () => {
 
     // Active price ticks over in this loop, this is to ensure the values align
     for (let i = 0; i <= 6; i++) {
-      const height = await container.getBlockCount()
-      await container.generate(1)
-      await service.waitForIndexedHeight(height)
-      await new Promise((resolve) => setTimeout(resolve, 500))
+      {
+        const height = await container.getBlockCount()
+        await container.generate(1)
+        await service.waitForIndexedHeight(height)
+        await new Promise((resolve) => setTimeout(resolve, 500))
+      }
 
       const fixedIntervalPrice = await testing.rpc.oracle.getFixedIntervalPrice('S1/USD')
       const activePrice = await apiClient.prices.getFeedActive('S1', 'USD', 1)

--- a/packages/whale-api-client/src/api/loan.ts
+++ b/packages/whale-api-client/src/api/loan.ts
@@ -1,6 +1,7 @@
 import { WhaleApiClient } from '../whale.api.client'
 import { ApiPagedResponse } from '../whale.api.response'
 import { TokenData } from './tokens'
+import { ActivePrice } from './prices'
 
 export class Loan {
   constructor (private readonly client: WhaleApiClient) {
@@ -162,4 +163,5 @@ export interface LoanVaultTokenAmount {
   displaySymbol: string
   symbolKey: string
   name: string
+  activePrice?: ActivePrice
 }

--- a/src/module.api/loan.vault.service.ts
+++ b/src/module.api/loan.vault.service.ts
@@ -20,12 +20,15 @@ import { TokenInfo } from '@defichain/jellyfish-api-core/dist/category/token'
 import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
 import { DeFiDCache } from '@src/module.api/cache/defid.cache'
 import { parseDisplaySymbol } from '@src/module.api/token.controller'
+import { ActivePrice } from '@whale-api-client/api/prices'
+import { OraclePriceActiveMapper } from '@src/module.model/oracle.price.active'
 
 @Injectable()
 export class LoanVaultService {
   constructor (
     private readonly client: JsonRpcClient,
-    private readonly deFiDCache: DeFiDCache
+    private readonly deFiDCache: DeFiDCache,
+    private readonly activePriceMapper: OraclePriceActiveMapper
   ) {
   }
 
@@ -107,18 +110,20 @@ export class LoanVaultService {
     const tokenInfos = await this.deFiDCache
       .batchTokenInfoBySymbol(tokenAmounts.map(([_, symbol]) => symbol))
 
-    return tokenAmounts
-      .map(([amount, symbol]): LoanVaultTokenAmount => {
-        const result = tokenInfos[symbol]
-        if (result === undefined) {
-          throw new ConflictException('unable to find token')
-        }
+    const mappedItems = tokenAmounts.map(async ([amount, symbol]): Promise<LoanVaultTokenAmount> => {
+      const result = tokenInfos[symbol]
+      if (result === undefined) {
+        throw new ConflictException('unable to find token')
+      }
 
-        const info = Object.values(result)[0]
-        const id = Object.keys(result)[0]
+      const info = Object.values(result)[0]
+      const id = Object.keys(result)[0]
+      const activePrice = await this.activePriceMapper.query(`${symbol}-USD`, 1)
+      return mapLoanVaultTokenAmount(id, info, amount, activePrice[0])
+    })
 
-        return mapLoanVaultTokenAmount(id, info, amount)
-      }).sort(a => Number.parseInt(a.id))
+    return (await Promise.all(mappedItems))
+      .sort(a => Number.parseInt(a.id))
   }
 
   private async mapLiquidationBatches (batches: VaultLiquidationBatch[]): Promise<LoanVaultLiquidationBatch[]> {
@@ -150,14 +155,15 @@ export class LoanVaultService {
   }
 }
 
-function mapLoanVaultTokenAmount (id: string, tokenInfo: TokenInfo, amount: string): LoanVaultTokenAmount {
+function mapLoanVaultTokenAmount (id: string, tokenInfo: TokenInfo, amount: string, activePrice?: ActivePrice): LoanVaultTokenAmount {
   return {
     id: id,
     amount: amount,
     symbol: tokenInfo.symbol,
     symbolKey: tokenInfo.symbolKey,
     name: tokenInfo.name,
-    displaySymbol: parseDisplaySymbol(tokenInfo)
+    displaySymbol: parseDisplaySymbol(tokenInfo),
+    activePrice: activePrice
   }
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:

Instead of getting the active price individually with `/prices` endpoint, this PR included the ActivePrice for all `VaultLoanTokenAmount` in `Vault`. This doesn't perform arithmetic on the amount to get the USD value, you need to perform this on your own at the client side.

> `ActivePrice` is fetched from Whale indexed database, this index is different from DeFiCh/ain, it index on its own spin loop cycle. `ActivePrice` can be undefined.