### PR TITLE
bump jellyfish deps to 2.6.0 globally

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16346,9 +16346,6 @@
         "abort-controller": "^3.0.0",
         "cross-fetch": "^3.1.2",
         "url-search-params-polyfill": "8.1.1"
-      },
-      "peerDependencies": {
-        "defichain": "^2.4.0"
       }
     },
     "packages/whale-api-wallet": {
@@ -16359,9 +16356,6 @@
         "@defichain/jellyfish-transaction-builder": "^2.5.0",
         "@defichain/jellyfish-wallet": "^2.5.0",
         "@defichain/whale-api-client": "0.0.0"
-      },
-      "peerDependencies": {
-        "defichain": "^2.4.0"
       }
     }
   },

--- a/packages/whale-api-client/package.json
+++ b/packages/whale-api-client/package.json
@@ -29,8 +29,5 @@
     "abort-controller": "^3.0.0",
     "cross-fetch": "^3.1.2",
     "url-search-params-polyfill": "8.1.1"
-  },
-  "peerDependencies": {
-    "defichain": "^2.4.0"
   }
 }

--- a/packages/whale-api-wallet/package.json
+++ b/packages/whale-api-wallet/package.json
@@ -27,8 +27,5 @@
     "@defichain/jellyfish-transaction-builder": "^2.5.0",
     "@defichain/jellyfish-wallet": "^2.5.0",
     "@defichain/whale-api-client": "0.0.0"
-  },
-  "peerDependencies": {
-    "defichain": "^2.4.0"
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind dependencies

Also, removed peer for the lib package as it's enforced by jellyfish packages.