### PR TITLE
update defid.probes.ts to use initialblockdownload 

### DIFF
--- a/src/module.defid/defid.probes.ts
+++ b/src/module.defid/defid.probes.ts
@@ -45,8 +45,8 @@ export class DeFiDProbeIndicator extends ProbeIndicator {
       peers: peers
     }
 
-    if (info.blocks + 4 <= info.headers) {
-      return this.withDead('defid', 'defid blocks are more than 4 headers behind', details)
+    if (info.initialblockdownload) {
+      return this.withDead('defid', 'defid is in initial block download', details)
     }
 
     if (peers === 0) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

To check if still syncing with `idb` instead of `headers` as headers can be ahead even if the blocks are invalid.
