### PR TITLE
moved prebuild into a script due to package.json parsing error in workflow

### DIFF
--- a/packages/whale-api-client/package.json
+++ b/packages/whale-api-client/package.json
@@ -21,8 +21,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "npm run version.ts && tsc",
-    "version.ts": "node -p \"'export default \\'v' + require('./package.json').version.replace(/\\.\\d+$/, '') + '\\''\" > src/version.ts"
+    "build": "./prebuild && tsc"
   },
   "dependencies": {
     "@defichain/jellyfish-api-core": "^2.9.0",

--- a/packages/whale-api-client/prebuild
+++ b/packages/whale-api-client/prebuild
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+node -p "'export default \'v' + require('./package.json').version.replace(/\.\d+$/, '') + '\''" > src/version.ts


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

Moved prebuild script `version.ts` (sets the versions for client) into an executable script due to `package.json` parsing error in `defichain-dependencies.yml`