### PR TITLE
Add highestBid returned object to vault and auction endpoints

### DIFF
--- a/packages/whale-api-client/__tests__/api/loan.auction.test.ts
+++ b/packages/whale-api-client/__tests__/api/loan.auction.test.ts
@@ -9,7 +9,7 @@ const service = new StubService(container)
 const client = new StubWhaleApiClient(service)
 const testing = Testing.create(container)
 
-let vaultId1
+let vaultId1: string
 
 beforeAll(async () => {
   await container.start()
@@ -128,7 +128,10 @@ beforeAll(async () => {
     fixedIntervalPriceId: 'AAPL/USD'
   })
   await testing.generate(1)
-  await testing.token.mint({ symbol: 'AAPL', amount: 10000 })
+  await testing.token.mint({
+    symbol: 'AAPL',
+    amount: 10000
+  })
   await testing.generate(1)
   await testing.rpc.loan.setLoanToken({
     symbol: 'TSLA',
@@ -296,8 +299,8 @@ describe('list', () => {
   it('should listAuction with size only', async () => {
     const result = await client.loan.listAuction(20)
     expect(result.length).toStrictEqual(4)
-    result.forEach((e) =>
-      expect(e).toStrictEqual({
+    result.forEach((vault) => {
+      expect(vault).toStrictEqual({
         batchCount: expect.any(Number),
         batches: expect.any(Object),
         loanScheme: expect.any(Object),
@@ -306,17 +309,44 @@ describe('list', () => {
         liquidationHeight: expect.any(Number),
         liquidationPenalty: expect.any(Number),
         vaultId: expect.any(String)
-      }
-      ))
+      })
 
-    result.forEach((e) =>
+      if (vaultId1 === vault.vaultId) {
+        expect(vault.batches).toStrictEqual([
+          {
+            collaterals: expect.any(Array),
+            highestBid: {
+              amount: {
+                activePrice: expect.any(Object),
+                amount: '8000.00000000',
+                displaySymbol: 'dAAPL',
+                id: expect.any(String),
+                name: expect.any(String),
+                symbol: 'AAPL',
+                symbolKey: 'AAPL'
+              },
+              owner: expect.any(String)
+            },
+            index: 0,
+            loan: expect.any(Object)
+          },
+          {
+            collaterals: expect.any(Array),
+            index: 1,
+            loan: expect.any(Object)
+          }
+        ])
+      }
+    })
+
+    result.forEach((e) => {
       e.batches.forEach((f) => {
         expect(typeof f.index).toBe('number')
         expect(typeof f.collaterals).toBe('object')
         expect(typeof f.loan).toBe('object')
         expect(typeof f.highestBid === 'object' || f.highestBid === undefined).toBe(true)
       })
-    )
+    })
   })
 
   it('should listAuction with size and pagination', async () => {

--- a/packages/whale-api-client/__tests__/api/loan.auction.test.ts
+++ b/packages/whale-api-client/__tests__/api/loan.auction.test.ts
@@ -128,6 +128,8 @@ beforeAll(async () => {
     fixedIntervalPriceId: 'AAPL/USD'
   })
   await testing.generate(1)
+  await testing.token.mint({ symbol: 'AAPL', amount: 10000 })
+  await testing.generate(1)
   await testing.rpc.loan.setLoanToken({
     symbol: 'TSLA',
     fixedIntervalPriceId: 'TSLA/USD'
@@ -272,6 +274,14 @@ beforeAll(async () => {
     const vault4 = await testing.rpc.loan.getVault(auction4.vaultId)
     expect(vault4.state).toStrictEqual('inLiquidation')
   }
+
+  await testing.rpc.account.sendTokensToAddress({}, { [collateralAddress]: ['8000@AAPL'] })
+  await testing.generate(1)
+
+  const txid = await testing.container.call('placeauctionbid', [vaultId1, 0, collateralAddress, '8000@AAPL'])
+  expect(typeof txid).toStrictEqual('string')
+  expect(txid.length).toStrictEqual(64)
+  await testing.generate(1)
 })
 
 afterAll(async () => {
@@ -301,11 +311,10 @@ describe('list', () => {
 
     result.forEach((e) =>
       e.batches.forEach((f) => {
-        expect(f).toStrictEqual({
-          index: expect.any(Number),
-          collaterals: expect.any(Object),
-          loan: expect.any(Object)
-        })
+        expect(typeof f.index).toBe('number')
+        expect(typeof f.collaterals).toBe('object')
+        expect(typeof f.loan).toBe('object')
+        expect(typeof f.highestBid === 'object' || f.highestBid === undefined).toBe(true)
       })
     )
   })

--- a/packages/whale-api-client/src/api/loan.ts
+++ b/packages/whale-api-client/src/api/loan.ts
@@ -159,6 +159,7 @@ export interface LoanVaultLiquidationBatch {
   index: number
   collaterals: LoanVaultTokenAmount[]
   loan: LoanVaultTokenAmount
+  highestBid?: HighestBid
 }
 
 export enum LoanVaultState {
@@ -177,4 +178,9 @@ export interface LoanVaultTokenAmount {
   symbolKey: string
   name: string
   activePrice?: ActivePrice
+}
+
+export interface HighestBid {
+  amount: string
+  owner: string
 }

--- a/packages/whale-api-client/src/api/loan.ts
+++ b/packages/whale-api-client/src/api/loan.ts
@@ -181,6 +181,6 @@ export interface LoanVaultTokenAmount {
 }
 
 export interface HighestBid {
-  amount: string
   owner: string
+  amount: LoanVaultTokenAmount
 }

--- a/src/module.api/loan.auction.controller.e2e.ts
+++ b/src/module.api/loan.auction.controller.e2e.ts
@@ -132,6 +132,8 @@ beforeAll(async () => {
     fixedIntervalPriceId: 'AAPL/USD'
   })
   await testing.generate(1)
+  await testing.token.mint({ symbol: 'AAPL', amount: 10000 })
+  await testing.generate(1)
   await testing.rpc.loan.setLoanToken({
     symbol: 'TSLA',
     fixedIntervalPriceId: 'TSLA/USD'
@@ -276,6 +278,14 @@ beforeAll(async () => {
     const vault4 = await testing.rpc.loan.getVault(auction4.vaultId)
     expect(vault4.state).toStrictEqual('inLiquidation')
   }
+
+  await testing.rpc.account.sendTokensToAddress({}, { [collateralAddress]: ['8000@AAPL'] })
+  await testing.generate(1)
+
+  const txid = await testing.container.call('placeauctionbid', [vaultId1, 0, collateralAddress, '8000@AAPL'])
+  expect(typeof txid).toStrictEqual('string')
+  expect(txid.length).toStrictEqual(64)
+  await testing.generate(1)
 })
 
 afterAll(async () => {
@@ -301,11 +311,10 @@ describe('list', () => {
 
     result.data.forEach((e) =>
       e.batches.forEach((f) => {
-        expect(f).toStrictEqual({
-          index: expect.any(Number),
-          collaterals: expect.any(Object),
-          loan: expect.any(Object)
-        })
+        expect(typeof f.index).toBe('number')
+        expect(typeof f.collaterals).toBe('object')
+        expect(typeof f.loan).toBe('object')
+        expect(typeof f.highestBid === 'object' || f.highestBid === undefined).toBe(true)
       })
     )
   })

--- a/src/module.api/loan.vault.service.ts
+++ b/src/module.api/loan.vault.service.ts
@@ -138,6 +138,28 @@ export class LoanVaultService {
     }
   }
 
+  private async mapLiquidationBatches (batches: VaultLiquidationBatch[]): Promise<LoanVaultLiquidationBatch[]> {
+    if (batches.length === 0) {
+      return []
+    }
+
+    const items = batches.map(async batch => {
+      return {
+        index: batch.index,
+        collaterals: await this.mapTokenAmounts(batch.collaterals),
+        loan: (await this.mapTokenAmounts([batch.loan]))[0],
+        highestBid: batch.highestBid !== undefined
+          ? {
+              owner: batch.highestBid.owner,
+              amount: (await this.mapTokenAmounts([batch.highestBid.amount]))[0]
+            }
+          : undefined
+      }
+    })
+
+    return await Promise.all(items)
+  }
+
   private async mapTokenAmounts (items?: string[]): Promise<LoanVaultTokenAmount[]> {
     if (items === undefined || items.length === 0) {
       return []
@@ -161,23 +183,6 @@ export class LoanVaultService {
 
     return (await Promise.all(mappedItems))
       .sort(a => Number.parseInt(a.id))
-  }
-
-  private async mapLiquidationBatches (batches: VaultLiquidationBatch[]): Promise<LoanVaultLiquidationBatch[]> {
-    if (batches.length === 0) {
-      return []
-    }
-
-    const items = batches.map(async batch => {
-      return {
-        index: batch.index,
-        collaterals: await this.mapTokenAmounts(batch.collaterals),
-        loan: (await this.mapTokenAmounts([batch.loan]))[0],
-        highestBid: batch.highestBid
-      }
-    })
-
-    return await Promise.all(items)
   }
 
   private async mapLoanScheme (id: string): Promise<LoanScheme> {

--- a/src/module.api/loan.vault.service.ts
+++ b/src/module.api/loan.vault.service.ts
@@ -170,9 +170,10 @@ export class LoanVaultService {
 
     const items = batches.map(async batch => {
       return {
-        index: batch.index as any, // fixed in https://github.com/DeFiCh/jellyfish/pull/805
+        index: batch.index,
         collaterals: await this.mapTokenAmounts(batch.collaterals),
-        loan: (await this.mapTokenAmounts([batch.loan]))[0]
+        loan: (await this.mapTokenAmounts([batch.loan]))[0],
+        highestBid: batch.highestBid
       }
     })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:
New highestBid object is added to listVaults, getVault and listAuctions RPCs. 

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:
