### PR TITLE
set /rawtx/send defaultMaxFeeRate to 0.1

### DIFF
--- a/packages/whale-api-client/__tests__/api/rawtx.test.ts
+++ b/packages/whale-api-client/__tests__/api/rawtx.test.ts
@@ -41,7 +41,8 @@ describe('test', () => {
   it('should accept valid txn with given maxFeeRate', async () => {
     const hex = await createSignedTxnHex(container, 10, 9.995)
     await client.rawtx.test({
-      hex: hex, maxFeeRate: 0.05
+      hex: hex,
+      maxFeeRate: 0.05
     })
   })
 
@@ -66,7 +67,8 @@ describe('test', () => {
     expect.assertions(2)
     try {
       await client.rawtx.test({
-        hex: hex, maxFeeRate: 1
+        hex: hex,
+        maxFeeRate: 1
       })
     } catch (err) {
       expect(err).toBeInstanceOf(WhaleApiException)
@@ -82,7 +84,7 @@ describe('test', () => {
 })
 
 describe('send', () => {
-  it('should send valid txn', async () => {
+  it('should send valid txn 0.0001 DFI as fees', async () => {
     const hex = await createSignedTxnHex(container, 10, 9.9999)
     const txid = await client.rawtx.send({
       hex: hex
@@ -94,10 +96,23 @@ describe('send', () => {
     expect(out.value).toStrictEqual(9.9999)
   })
 
+  it('should send valid txn 0.01 DFI as fees', async () => {
+    const hex = await createSignedTxnHex(container, 10, 9.99)
+    const txid = await client.rawtx.send({
+      hex: hex
+    })
+    expect(txid.length).toStrictEqual(64)
+
+    await container.generate(1)
+    const out = await container.call('gettxout', [txid, 0])
+    expect(out.value).toStrictEqual(9.99)
+  })
+
   it('should send valid txn with given maxFeeRate', async () => {
     const hex = await createSignedTxnHex(container, 10, 9.995)
     const txid = await client.rawtx.send({
-      hex: hex, maxFeeRate: 0.05
+      hex: hex,
+      maxFeeRate: 0.05
     })
     expect(txid.length).toStrictEqual(64)
 
@@ -130,7 +145,8 @@ describe('send', () => {
     expect.assertions(2)
     try {
       await client.rawtx.send({
-        hex: hex, maxFeeRate: 1
+        hex: hex,
+        maxFeeRate: 1
       })
     } catch (err) {
       expect(err).toBeInstanceOf(WhaleApiException)
@@ -140,6 +156,23 @@ describe('send', () => {
         at: expect.any(Number),
         url: '/v0.0/regtest/rawtx/send',
         message: 'Absurdly high fee'
+      })
+    }
+  })
+
+  it('should fail due to high fees using default values', async () => {
+    const hex = await createSignedTxnHex(container, 10, 9.95)
+    expect.assertions(2)
+    try {
+      await client.rawtx.send({ hex: hex })
+    } catch (err) {
+      expect(err).toBeInstanceOf(WhaleApiException)
+      expect(err.error).toStrictEqual({
+        code: 400,
+        type: 'BadRequest',
+        at: expect.any(Number),
+        message: 'Absurdly high fee',
+        url: '/v0.0/regtest/rawtx/send'
       })
     }
   })
@@ -189,7 +222,8 @@ describe('send', () => {
     expect.assertions(3)
     try {
       await client.rawtx.send({
-        hex: '00', maxFeeRate: -1.5
+        hex: '00',
+        maxFeeRate: -1.5
       })
       expect('must fail').toBeUndefined()
     } catch (err) {
@@ -209,8 +243,9 @@ describe('send', () => {
     expect.assertions(3)
     try {
       await client.rawtx.send({
+        hex: '00',
         // @ts-expect-error
-        hex: '00', maxFeeRate: 'abc'
+        maxFeeRate: 'abc'
       })
       expect('must fail').toBeUndefined()
     } catch (err) {

--- a/src/module.api/rawtx.controller.ts
+++ b/src/module.api/rawtx.controller.ts
@@ -28,12 +28,12 @@ class RawTxDto {
 export class RawtxController {
   /**
    * MaxFeeRate = vkb * Fees
-   * This will max out at around 0.001 DFI per average transaction (200vb).
+   * This will max out at around 0.02 DFI per average transaction (200vb). 0.1/1000*200 = 0.02 DIF
    * @example A typical P2WPKH 1 to 1 transaction is 110.5vb
    * @example A typical P2WPKH 1 to 2 transaction is 142.5vb
    * @example A typical P2WPKH 1 to 1 + dftx transaction is around ~200vb.
    */
-  private readonly defaultMaxFeeRate: BigNumber = new BigNumber('0.005')
+  private readonly defaultMaxFeeRate: BigNumber = new BigNumber('0.1')
 
   constructor (
     private readonly client: JsonRpcClient,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

Remove lower limit and set to a default of 0.1 DFI for `/rawtx/send` and `/rawtx/test` operations due to increased transaction defichain is handling.
