### PR TITLE
chore(health): allow model readiness synced blocks to be up to 10 blocks behind

### DIFF
--- a/src/module.model/_model.probes.ts
+++ b/src/module.model/_model.probes.ts
@@ -55,8 +55,8 @@ export class ModelProbeIndicator extends ProbeIndicator {
       return this.withDead('model', 'synced blocks are undefined', details)
     }
 
-    if (index + 4 <= defid) {
-      return this.withDead('model', 'synced blocks are more than 4 blocks behind', details)
+    if (index + 10 <= defid) {
+      return this.withDead('model', 'synced blocks are more than 10 blocks behind', details)
     }
 
     return this.withAlive('model', details)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore
