### PR TITLE
chore(whale-api-client): increase prevout size to 200 for WhaleWalletAccount

### DIFF
--- a/packages/whale-api-wallet/src/wallet.ts
+++ b/packages/whale-api-wallet/src/wallet.ts
@@ -13,7 +13,7 @@ export class WhaleWalletAccount extends WalletAccount {
     public readonly client: WhaleApiClient,
     walletEllipticPair: WalletEllipticPair,
     network: Network,
-    prevoutSize: number = 50
+    prevoutSize: number = 200
   ) {
     super(walletEllipticPair, network)
     this.feeRateProvider = new WhaleFeeRateProvider(client)


### PR DESCRIPTION
#### What kind of PR is this?:

/kind chore

#### What this PR does / why we need it:

Increase prevout size from 50 to 200 for WhaleWalletAccount PrevoutProvider. This allows more prevout to be collected for Whale Wallet Transaction creation.