### PR TITLE
chore(database): increase max open file and max file size to benefit modern system

### DIFF
--- a/src/module.database/provider.level/level.database.ts
+++ b/src/module.database/provider.level/level.database.ts
@@ -148,6 +148,9 @@ export abstract class LevelUpDatabase extends Database {
  */
 export class LevelDatabase extends LevelUpDatabase {
   constructor (@Inject('LEVEL_UP_LOCATION') location: string) {
-    super(level(location))
+    super(level(location, {
+      maxOpenFiles: 2000,
+      maxFileSize: 8 * 1024 * 1024
+    }))
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

LevelDB was created long ago in the era of rotating disks. While level has RocksDB is a drop-in replacement for LevelDB, it's not as widely used (https://www.npmjs.com/package/rocksdb vs https://www.npmjs.com/package/level).

This PR attempts to tune the SSTable settings by allowing more files to be opened and increasing the size of each file that will benefit modern systems.

Related to https://github.com/DeFiCh/jellyfish/issues/979