### PR TITLE
chore(model.probes.ts): change model readiness window to 4

### DIFF
--- a/src/module.model/_model.probes.ts
+++ b/src/module.model/_model.probes.ts
@@ -55,7 +55,7 @@ export class ModelProbeIndicator extends ProbeIndicator {
       return this.withDead('model', 'synced blocks are undefined', details)
     }
 
-    if (index + 10 <= defid) {
+    if (index + 4 <= defid) {
       return this.withDead('model', 'synced blocks are more than 10 blocks behind', details)
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

A window of 10 is too wide, changing to back to 4. If any health check configuration is to be done; it should be done on the server side,