### PR TITLE
chore(indexer): reduce the amount of RPC call from 4 to 2 for indexing

### DIFF
--- a/src/e2e.module.ts
+++ b/src/e2e.module.ts
@@ -108,8 +108,11 @@ export async function invalidateFromHeight (app: NestFastifyApplication, contain
   const invalidateBlockHash = await container.call('getblockhash', [invalidateHeight])
   await container.call('invalidateblock', [invalidateBlockHash])
   await container.call('clearmempool')
-  await container.generate(height - invalidateHeight + 1)
+  // +1 more so that RPCBlockProvider.synchronize can update to next block.
+  // New behavior where RPCBlockProvider won't invalidate block on the same height as itself
+  await container.generate(height - invalidateHeight + 2)
   const blockMapper = app.get(BlockMapper)
+
   await waitForExpect(async () => {
     const block = await blockMapper.getByHeight(height)
     expect(block).not.toStrictEqual(undefined)

--- a/src/module.indexer/rpc.block.provider.ts
+++ b/src/module.indexer/rpc.block.provider.ts
@@ -7,6 +7,7 @@ import { IndexStatusMapper, Status } from '@src/module.indexer/status'
 import { TokenMapper } from '@src/module.model/token'
 import { HexEncoder } from '@src/module.model/_hex.encoder'
 import { waitForCondition } from '@defichain/testcontainers/dist/utils'
+import { blockchain as defid } from '@defichain/jellyfish-api-core'
 
 @Injectable()
 export class RPCBlockProvider {
@@ -78,27 +79,31 @@ export class RPCBlockProvider {
       return await this.indexGenesis()
     }
 
-    if (await this.isBestChain(indexed)) {
-      const highest = await this.client.blockchain.getBlockCount()
-      const nextHeight = indexed.height + 1
-      if (nextHeight > highest) {
-        return false // won't attempt to index ahead
+    let nextHash: string
+    try {
+      nextHash = await this.client.blockchain.getBlockHash(indexed.height + 1)
+    } catch (err) {
+      if (err.payload.message === 'Block height out of range') {
+        return false
       }
+      throw err
+    }
 
-      const nextHash = await this.client.blockchain.getBlockHash(nextHeight)
-      // TODO(fuxingloh): nextHeight, getBlock
-      // TODO(fuxingloh): check prev block is indexed else invalidate current block
-
-      await this.index(nextHash, nextHeight)
+    const nextBlock = await this.client.blockchain.getBlock(nextHash, 2)
+    if (await RPCBlockProvider.isBestChain(indexed, nextBlock)) {
+      await this.index(nextBlock)
     } else {
       await this.invalidate(indexed.hash, indexed.height)
     }
     return true
   }
 
-  private async isBestChain (indexed: Block): Promise<boolean> {
-    const hash = await this.client.blockchain.getBlockHash(indexed.height)
-    return hash === indexed.hash
+  /**
+   * @param {Block} indexed previous block
+   * @param {defid.Block<Transaction>} nextBlock to check previous block hash
+   */
+  private static async isBestChain (indexed: Block, nextBlock: defid.Block<defid.Transaction>): Promise<boolean> {
+    return nextBlock.previousblockhash === indexed.hash
   }
 
   public async indexGenesis (): Promise<boolean> {
@@ -149,16 +154,15 @@ export class RPCBlockProvider {
     await this.invalidate(status.hash, status.height)
   }
 
-  private async index (hash: string, height: number): Promise<void> {
-    this.logger.log(`Index - hash: ${hash} - height: ${height}`)
-    const block = await this.client.blockchain.getBlock(hash, 2)
-    await this.statusMapper.put(hash, height, Status.INDEXING)
+  private async index (block: defid.Block<defid.Transaction>): Promise<void> {
+    this.logger.log(`Index - hash: ${block.hash} - height: ${block.height}`)
+    await this.statusMapper.put(block.hash, block.height, Status.INDEXING)
 
     try {
       await this.indexer.index(block)
-      await this.statusMapper.put(hash, height, Status.INDEXED)
+      await this.statusMapper.put(block.hash, block.height, Status.INDEXED)
     } catch (err) {
-      await this.statusMapper.put(hash, height, Status.ERROR)
+      await this.statusMapper.put(block.hash, block.height, Status.ERROR)
       throw err
     }
   }

--- a/src/module.indexer/rpc.block.provider.ts
+++ b/src/module.indexer/rpc.block.provider.ts
@@ -86,6 +86,9 @@ export class RPCBlockProvider {
       }
 
       const nextHash = await this.client.blockchain.getBlockHash(nextHeight)
+      // TODO(fuxingloh): nextHeight, getBlock
+      // TODO(fuxingloh): check prev block is indexed else invalidate current block
+
       await this.index(nextHash, nextHeight)
     } else {
       await this.invalidate(indexed.hash, indexed.height)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

After `const indexed = await this.blockMapper.getHighest()`

Previously 4 RPC to check if there is a new block:
1. `isBestChain()` -> `this.client.blockchain.getBlockHash(indexed.height)`
2. `const highest = await this.client.blockchain.getBlockCount()` for `if (indexed.height + 1 > highest)` for has next block
3. `const nextHash = await this.client.blockchain.getBlockHash(nextHeight)`
4. `const block = await this.client.blockchain.getBlock(hash, 2)`

This new implementation optimizes the RPCBlockProvider to just use 2 RPC call with the same result:
1. `const nextHash = await this.client.blockchain.getBlockHash(indexed.height + 1)`
    - returns if not found = no next block
2. `const nextBlock = await this.client.blockchain.getBlock(nextHash, 2)` 
    - Also compare isBestChain via `nextBlock.previousblockhash === indexed.hash`

Within `e2e.module.ts` `invalidateFromHeight()` +1 more block height so that `RPCBlockProvider.synchronize()` can update to next block. To fix a new behavior where RPCBlockProvider won't invalidate block on the same height as itself.

---

Related to https://github.com/DeFiCh/jellyfish/issues/979