### PR TITLE
chore(health-check): readiness synced blocks are more than 2 blocks behind

### DIFF
--- a/src/module.model/_model.probes.ts
+++ b/src/module.model/_model.probes.ts
@@ -31,7 +31,7 @@ export class ModelProbeIndicator extends ProbeIndicator {
    * Readiness of Model Database
    * - unable to get the latest block
    * - synced blocks are undefined
-   * - synced blocks are more than 4 blocks behind
+   * - synced blocks are more than 2 blocks behind
    */
   async readiness (): Promise<HealthIndicatorResult> {
     let index: number | undefined
@@ -55,8 +55,8 @@ export class ModelProbeIndicator extends ProbeIndicator {
       return this.withDead('model', 'synced blocks are undefined', details)
     }
 
-    if (index + 4 <= defid) {
-      return this.withDead('model', 'synced blocks are more than 10 blocks behind', details)
+    if (index + 2 <= defid) {
+      return this.withDead('model', 'synced blocks are more than 2 blocks behind', details)
     }
 
     return this.withAlive('model', details)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

Lower and move service reliability granularity to orchestrator services.
