### PR TITLE
feature(json-rpc): expose whitelisted defid JSON RPC 1.0

### DIFF
--- a/.idea/dictionaries/fuxing.xml
+++ b/.idea/dictionaries/fuxing.xml
@@ -57,7 +57,9 @@
       <w>getblockchaininfo</w>
       <w>getblockcount</w>
       <w>getblockhash</w>
+      <w>getblockstats</w>
       <w>getconnectioncount</w>
+      <w>getgov</w>
       <w>getmintinginfo</w>
       <w>getnetworkhashps</w>
       <w>getnewaddress</w>
@@ -92,6 +94,7 @@
       <w>lessthanorequal</w>
       <w>lexint</w>
       <w>libevent</w>
+      <w>listaccounthistory</w>
       <w>listaccounts</w>
       <w>listaddressgroupings</w>
       <w>listpoolpairs</w>

--- a/package-lock.json
+++ b/package-lock.json
@@ -16293,7 +16293,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@defichain/jellyfish-api-core": "^2.17.0",
+        "@defichain/jellyfish-api-jsonrpc": "^2.17.0",
         "abort-controller": "^3.0.0",
         "cross-fetch": "^3.1.5",
         "url-search-params-polyfill": "8.1.1"
@@ -17047,7 +17047,7 @@
     "@defichain/whale-api-client": {
       "version": "file:packages/whale-api-client",
       "requires": {
-        "@defichain/jellyfish-api-core": "^2.17.0",
+        "@defichain/jellyfish-api-jsonrpc": "^2.17.0",
         "abort-controller": "^3.0.0",
         "cross-fetch": "^3.1.5",
         "url-search-params-polyfill": "8.1.1"

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -3,7 +3,7 @@
     "declaration": true,
     "target": "es6",
     "lib": [
-      "es2020"
+      "es2020", "dom"
     ],
     "module": "commonjs",
     "strict": true,

--- a/packages/whale-api-client/__tests__/stub.client.ts
+++ b/packages/whale-api-client/__tests__/stub.client.ts
@@ -1,5 +1,7 @@
-import { Method, ResponseAsString, WhaleApiClient } from '../src'
+import { Method, ResponseAsString, WhaleApiClient, WhaleRpcClient } from '../src'
 import { StubService } from './stub.service'
+import version from '../src/version'
+import AbortController from 'abort-controller'
 
 /**
  * Client stubs are simulations of a real client, which are used for functional testing.
@@ -26,6 +28,38 @@ export class StubWhaleApiClient extends WhaleApiClient {
     return {
       body: res.body,
       status: res.statusCode
+    }
+  }
+}
+
+export class StubWhaleRpcClient extends WhaleRpcClient {
+  constructor (readonly service: StubService) {
+    super('not required for stub service')
+  }
+
+  protected async fetch (body: string, controller: AbortController): Promise<Response> {
+    if (this.service.app === undefined) {
+      throw new Error('StubService is not yet started.')
+    }
+
+    const res = await this.service.app.inject({
+      method: 'POST',
+      url: `/${version}/regtest/rpc`,
+      payload: body,
+      headers: { 'Content-Type': 'application/json' }
+    })
+
+    // @ts-expect-error
+    return {
+      url: res.raw.req.url,
+      ok: res.statusCode === 200,
+      redirected: false,
+      status: res.statusCode,
+      statusText: res.statusMessage,
+      bodyUsed: true,
+      async text (): Promise<string> {
+        return res.body
+      }
     }
   }
 }

--- a/packages/whale-api-client/__tests__/whale.rpc.client.test.ts
+++ b/packages/whale-api-client/__tests__/whale.rpc.client.test.ts
@@ -1,7 +1,7 @@
 import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { WhaleRpcClient } from '../src'
 import { StubService } from './stub.service'
-import { StubWhaleApiClient } from './stub.client'
+import { StubWhaleRpcClient } from './stub.client'
 
 let container: MasterNodeRegTestContainer
 let service: StubService
@@ -10,10 +10,9 @@ let client: WhaleRpcClient
 beforeAll(async () => {
   container = new MasterNodeRegTestContainer()
   service = new StubService(container)
-  client = new WhaleRpcClient(new StubWhaleApiClient(service))
+  client = new StubWhaleRpcClient(service)
 
   await container.start()
-  await container.waitForReady()
   await service.start()
 })
 
@@ -28,7 +27,13 @@ afterAll(async () => {
 it('should not be able to access wallet', async () => {
   return await expect(async () => {
     await client.wallet.getBalance()
-  }).rejects.toThrow('WhaleRpcClient: wallet.getBalance not enabled in WhaleApiClient')
+  }).rejects.toThrow('RpcApiError: \'undefined\', code: 422, method: getbalance')
+})
+
+it('should not be able to access accounts', async () => {
+  return await expect(async () => {
+    await client.account.listAccountHistory()
+  }).rejects.toThrow('RpcApiError: \'undefined\', code: 422, method: listaccounthistory')
 })
 
 describe('whitelisted rpc methods', () => {

--- a/packages/whale-api-client/__tests__/whale.rpc.client.test.ts
+++ b/packages/whale-api-client/__tests__/whale.rpc.client.test.ts
@@ -27,13 +27,13 @@ afterAll(async () => {
 it('should not be able to access wallet', async () => {
   return await expect(async () => {
     await client.wallet.getBalance()
-  }).rejects.toThrow('RpcApiError: \'undefined\', code: 422, method: getbalance')
+  }).rejects.toThrow('ClientApiError: 422 - Unprocessable Entity')
 })
 
 it('should not be able to access accounts', async () => {
   return await expect(async () => {
     await client.account.listAccountHistory()
-  }).rejects.toThrow('RpcApiError: \'undefined\', code: 422, method: listaccounthistory')
+  }).rejects.toThrow('ClientApiError: 422 - Unprocessable Entity')
 })
 
 describe('whitelisted rpc methods', () => {

--- a/packages/whale-api-client/package.json
+++ b/packages/whale-api-client/package.json
@@ -24,7 +24,7 @@
     "build": "./prebuild && tsc"
   },
   "dependencies": {
-    "@defichain/jellyfish-api-core": "^2.17.0",
+    "@defichain/jellyfish-api-jsonrpc": "^2.17.0",
     "abort-controller": "^3.0.0",
     "cross-fetch": "^3.1.5",
     "url-search-params-polyfill": "8.1.1"

--- a/packages/whale-api-client/src/api/rpc.ts
+++ b/packages/whale-api-client/src/api/rpc.ts
@@ -3,6 +3,9 @@ import { WhaleApiClient } from '../whale.api.client'
 import { WhaleApiResponse } from '../whale.api.response'
 import { raiseIfError } from '../errors'
 
+/**
+ * @deprecated since 0.22.x, please use WhaleRpcClient directly
+ */
 export class Rpc {
   constructor (private readonly client: WhaleApiClient) {
   }

--- a/packages/whale-api-client/src/whale.rpc.client.ts
+++ b/packages/whale-api-client/src/whale.rpc.client.ts
@@ -1,38 +1,25 @@
-import { ApiClient, Precision, PrecisionPath } from '@defichain/jellyfish-api-core'
-import { WhaleApiClient } from './whale.api.client'
-import { Wallet } from '@defichain/jellyfish-api-core/dist/category/wallet'
-import { Net } from '@defichain/jellyfish-api-core/dist/category/net'
+import { ClientOptions, JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
 
 /**
- * A JSON-RPC client implemented with WhaleApiClient.call specification.
+ * A JSON-RPC client implemented to interface with Whale RpcController.
+ *
  * Not all methods are whitelisted.
  */
-export class WhaleRpcClient extends ApiClient {
-  wallet = NotEnabledProxy<Wallet>('wallet')
-  net = NotEnabledProxy<Net>('net')
-
-  constructor (protected readonly whaleApiClient: WhaleApiClient) {
-    super()
-  }
-
+export class WhaleRpcClient extends JsonRpcClient {
   /**
-   * Implements jellyfish-api-core ApiClient by routing to WhaleApiClient.call
+   * MainNet Stable: https://ocean.defichain.com/v0/mainnet/rpc
+   * MainNet Edge:   https://ocean.defichain.com/v0.x/mainnet/rpc
    *
-   * @param {string} method the RPC method
-   * @param {any[]} params to send upstream
-   * @param {Precision | PrecisionPath} precision for JSON parsing
-   * @throws WhaleApiException instanceof for upstream errors
-   * @throws WhaleClientException instanceof for local issues
+   * @param {string} url
+   * @param {ClientOptions} [options=undefined]
    */
-  async call<T> (method: string, params: any[], precision: Precision | PrecisionPath): Promise<T> {
-    return await this.whaleApiClient.rpc.call(method, params, precision)
+  constructor (url: string = 'https://ocean.defichain.com/v0/mainnet/rpc', options?: ClientOptions) {
+    super(url, {
+      ...options,
+      headers: {
+        ...options?.headers,
+        'Content-Type': 'application/json'
+      }
+    })
   }
-}
-
-function NotEnabledProxy<T> (category: string): T {
-  return new Proxy({}, {
-    get (target, prop) {
-      throw new Error(`WhaleRpcClient: ${category}.${prop as string} not enabled in WhaleApiClient`)
-    }
-  }) as T
 }

--- a/packages/whale-api-client/src/whale.rpc.client.ts
+++ b/packages/whale-api-client/src/whale.rpc.client.ts
@@ -11,7 +11,7 @@ export class WhaleRpcClient extends JsonRpcClient {
    * MainNet Edge:   https://ocean.defichain.com/v0.x/mainnet/rpc
    *
    * @param {string} url
-   * @param {ClientOptions} [options=undefined]
+   * @param {ClientOptions} [options]
    */
   constructor (url: string = 'https://ocean.defichain.com/v0/mainnet/rpc', options?: ClientOptions) {
     super(url, {

--- a/src/module.api/_core/api.paged.response.ts
+++ b/src/module.api/_core/api.paged.response.ts
@@ -1,4 +1,4 @@
-import { ApiResponse } from '@src/module.api/_core/api.response'
+import { ApiRawResponse } from './api.response'
 
 /**
  * ApiPage for pagination ApiPagedResponse pagination
@@ -62,11 +62,12 @@ export interface ApiPage {
  * Answer: Blocks sorted by height in descending order, that's your sorted list and your slice window.
  *       : <- Latest | [100] [99] [98] [97] [...] | Oldest ->
  */
-export class ApiPagedResponse<T> implements ApiResponse {
+export class ApiPagedResponse<T> extends ApiRawResponse {
   data: T[]
   page?: ApiPage
 
   protected constructor (data: T[], next?: string) {
+    super()
     this.data = data
     this.page = next !== undefined ? { next } : undefined
   }

--- a/src/module.api/_core/api.response.ts
+++ b/src/module.api/_core/api.response.ts
@@ -9,3 +9,12 @@ export interface ApiResponse {
   page?: ApiPage
   error?: ApiError
 }
+
+/* eslint-disable @typescript-eslint/no-extraneous-class */
+/**
+ * Raw Abstract ApiResponse class to bypass ResponseInterceptor.
+ * Used by ApiPagedResponse to structure paged response structure.
+ */
+export abstract class ApiRawResponse implements ApiResponse {
+
+}

--- a/src/module.api/interceptors/response.interceptor.ts
+++ b/src/module.api/interceptors/response.interceptor.ts
@@ -1,8 +1,7 @@
 import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common'
 import { Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
-import { ApiPagedResponse } from '@src/module.api/_core/api.paged.response'
-import { ApiResponse } from '@src/module.api/_core/api.response'
+import { ApiResponse, ApiRawResponse } from '@src/module.api/_core/api.response'
 import { isVersionPrefixed } from '@src/module.api/_core/api.version'
 
 /**
@@ -18,7 +17,7 @@ export class ResponseInterceptor<T> implements NestInterceptor<T, ApiResponse> {
     }
 
     return next.handle().pipe(map(result => {
-      if (result instanceof ApiPagedResponse) {
+      if (result instanceof ApiRawResponse) {
         return result
       }
 

--- a/src/module.api/rpc.controller.spec.ts
+++ b/src/module.api/rpc.controller.spec.ts
@@ -9,7 +9,6 @@ let controller: RpcController
 
 beforeAll(async () => {
   await container.start()
-  await container.waitForReady()
   client = new JsonRpcClient(await container.getCachedRpcUrl())
 })
 
@@ -20,13 +19,23 @@ afterAll(async () => {
 beforeEach(async () => {
   const app: TestingModule = await Test.createTestingModule({
     controllers: [RpcController],
-    providers: [{ provide: JsonRpcClient, useValue: client }]
+    providers: [{
+      provide: JsonRpcClient,
+      useValue: client
+    }]
   }).compile()
 
   controller = app.get<RpcController>(RpcController)
 })
 
-it('should getblockchaininfo', async () => {
+it('should getblockchaininfo via deprecated endpoint', async () => {
   const result = await controller.call('getblockchaininfo', undefined)
   expect(result.chain).toStrictEqual('regtest')
+})
+
+it('should getblockchaininfo via JSON RPC 1.0', async () => {
+  const result = await controller.post({
+    method: 'getblockchaininfo'
+  })
+  expect(result.result.chain).toStrictEqual('regtest')
 })

--- a/src/module.api/rpc.controller.ts
+++ b/src/module.api/rpc.controller.ts
@@ -13,6 +13,7 @@ import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
 import { IsArray, IsIn, IsNotEmpty, IsOptional, IsString } from 'class-validator'
 import { ApiRawResponse } from '@src/module.api/_core/api.response'
 import { RpcApiError } from '@defichain/jellyfish-api-core'
+import { Transform } from 'class-transformer'
 
 /**
  * MethodWhitelist is a whitelist validation pipe to check
@@ -29,7 +30,9 @@ export class MethodWhitelist implements PipeTransform {
     'getblockchaininfo',
     'getblockhash',
     'getblockcount',
-    'getblock'
+    'getblock',
+    'getblockstats',
+    'getgov'
   ]
 
   transform (value: string, metadata: ArgumentMetadata): string {
@@ -54,7 +57,8 @@ export class JSONRPC {
 
   @IsOptional()
   @IsArray()
-  params!: any[]
+  @Transform(({ value }) => value !== undefined ? value : [])
+  params?: any[]
 }
 
 @Controller('/rpc')
@@ -65,7 +69,7 @@ export class RpcController {
   @Post()
   async post (@Body() rpc: JSONRPC): Promise<ApiRpcResponse> {
     try {
-      const result = await this.client.call(rpc.method, rpc.params, 'lossless')
+      const result = await this.client.call(rpc.method, rpc.params ?? [], 'lossless')
       return new ApiRpcResponse(result)
     } catch (err: any) {
       if (err instanceof RpcApiError || err.payload !== undefined) {

--- a/src/module.api/rpc.controller.ts
+++ b/src/module.api/rpc.controller.ts
@@ -10,6 +10,9 @@ import {
   Post
 } from '@nestjs/common'
 import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
+import { IsArray, IsIn, IsNotEmpty, IsOptional, IsString } from 'class-validator'
+import { ApiRawResponse } from '@src/module.api/_core/api.response'
+import { RpcApiError } from '@defichain/jellyfish-api-core'
 
 /**
  * MethodWhitelist is a whitelist validation pipe to check
@@ -17,7 +20,7 @@ import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
  * Non whitelisted method call will result in a ForbiddenException.
  *
  * Direct access to DeFiD should not be allowed,
- * that could used used as an attack against DeFi whale services.
+ * that could be used as an attack against DeFi whale services.
  * (by changing our peers)
  */
 @Injectable()
@@ -37,11 +40,21 @@ export class MethodWhitelist implements PipeTransform {
   }
 }
 
-/**
- * Call Data Transfer Object
- */
-export class CallDto {
+export class JSONRPCParams {
   params?: any[]
+}
+
+export class JSONRPC {
+  @IsString()
+  @IsNotEmpty()
+  @IsIn(MethodWhitelist.methods, {
+    message: 'RPC method not whitelisted'
+  })
+  method!: string
+
+  @IsOptional()
+  @IsArray()
+  params!: any[]
 }
 
 @Controller('/rpc')
@@ -49,9 +62,33 @@ export class RpcController {
   constructor (private readonly client: JsonRpcClient) {
   }
 
+  @Post()
+  async post (@Body() rpc: JSONRPC): Promise<ApiRpcResponse> {
+    try {
+      const result = await this.client.call(rpc.method, rpc.params, 'lossless')
+      return new ApiRpcResponse(result)
+    } catch (err: any) {
+      if (err instanceof RpcApiError || err.payload !== undefined) {
+        return new ApiRpcResponse(null, err.payload)
+      }
+
+      throw err
+    }
+  }
+
   @Post('/:method')
   @HttpCode(200)
-  async call (@Param('method', MethodWhitelist) method: string, @Body() callDto?: CallDto): Promise<any> {
+  async call (@Param('method', MethodWhitelist) method: string, @Body() callDto?: JSONRPCParams): Promise<any> {
     return await this.client.call(method, callDto?.params ?? [], 'lossless')
+  }
+}
+
+class ApiRpcResponse extends ApiRawResponse {
+  constructor (
+    public readonly result: any | null,
+    public readonly error: any = null,
+    public readonly id: null = null
+  ) {
+    super()
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:

Expose whitelisted JSON RPC 1.0 directly via RpcController so that `@defichain/jellyfish-api-jsonrpc` can use Ocean infrastructure directly.