### PR TITLE
chore(indexer): reverse bucket loop order, to exit when an index when interval already exist

### DIFF
--- a/src/module.indexer/model/dftx/pool.swap.aggregated.ts
+++ b/src/module.indexer/model/dftx/pool.swap.aggregated.ts
@@ -29,14 +29,14 @@ export class PoolSwapAggregatedIndexer extends DfTxIndexer<PoolSwap> {
   async indexBlockStart (block: RawBlock): Promise<void> {
     const poolPairs = await this.poolPairTokenMapper.listAllDesc()
 
-    for (const poolPair of poolPairs) {
-      for (const interval of AggregatedIntervals) {
+    for (const interval of AggregatedIntervals) {
+      for (const poolPair of poolPairs) {
         const previous = await this.aggregatedMapper.query(`${poolPair.poolPairId}-${interval as number}`, 1)
         const bucket = getBucket(block, interval)
 
         if (previous.length === 1 && previous[0].bucket >= bucket) {
           // Going from a desc-ing order, we can just check if the most recent PoolSwap Aggregation Bucket is added.
-          continue
+          break
         }
 
         await this.createNewBucket(block, poolPair.poolPairId, interval)


### PR DESCRIPTION
#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

Bucket indexer performance optimization.