### PR TITLE
feature(controller): Resolve PoolSwap from/to from `AccountHistory`

### DIFF
--- a/.idea/dictionaries/fuxing.xml
+++ b/.idea/dictionaries/fuxing.xml
@@ -135,6 +135,7 @@
       <w>pooledtx</w>
       <w>poolpair</w>
       <w>poolpairs</w>
+      <w>poolswap</w>
       <w>previousblockhash</w>
       <w>prevout</w>
       <w>prevouts</w>

--- a/packages/whale-api-client/__tests__/api/poolpairs.test.ts
+++ b/packages/whale-api-client/__tests__/api/poolpairs.test.ts
@@ -3,7 +3,7 @@ import { StubWhaleApiClient } from '../stub.client'
 import { StubService } from '../stub.service'
 import { ApiPagedResponse, WhaleApiClient, WhaleApiException } from '../../src'
 import { addPoolLiquidity, createPoolPair, createToken, getNewAddress, mintTokens, poolSwap } from '@defichain/testing'
-import { PoolPairData, PoolSwapData, PoolSwapAggregatedData, PoolSwapAggregatedInterval } from '../../src/api/poolpairs'
+import { PoolPairData, PoolSwapAggregatedData, PoolSwapAggregatedInterval, PoolSwapData } from '../../src/api/poolpairs'
 import { Testing } from '@defichain/jellyfish-testing'
 
 let container: MasterNodeRegTestContainer
@@ -372,15 +372,94 @@ describe('poolswap', () => {
     await service.waitForIndexedHeight(height)
 
     const response: ApiPagedResponse<PoolSwapData> = await client.poolpairs.listPoolSwaps('9')
-
-    // TODO(fuxingloh):
-    console.log(response)
-    expect(response.length).toStrictEqual(2)
     expect(response.hasNext).toStrictEqual(false)
-    expect(response[0].fromAmount).toStrictEqual('50.00000000')
-    expect(response[1].fromAmount).toStrictEqual('25.00000000')
-    expect(response[0].fromTokenId).toStrictEqual(1)
-    expect(response[1].fromTokenId).toStrictEqual(1)
+    expect([...response]).toStrictEqual([
+      {
+        id: expect.any(String),
+        txid: expect.stringMatching(/[0-f]{64}/),
+        txno: 1,
+        poolPairId: '9',
+        sort: expect.any(String),
+        fromAmount: '50.00000000',
+        fromTokenId: 1,
+        block: {
+          hash: expect.stringMatching(/[0-f]{64}/),
+          height: expect.any(Number),
+          time: expect.any(Number),
+          medianTime: expect.any(Number)
+        }
+      },
+      {
+        id: expect.any(String),
+        txid: expect.stringMatching(/[0-f]{64}/),
+        txno: 3,
+        poolPairId: '9',
+        sort: expect.any(String),
+        fromAmount: '25.00000000',
+        fromTokenId: 1,
+        block: {
+          hash: expect.stringMatching(/[0-f]{64}/),
+          height: expect.any(Number),
+          time: expect.any(Number),
+          medianTime: expect.any(Number)
+        }
+      }
+    ])
+
+    const verbose: ApiPagedResponse<PoolSwapData> = await client.poolpairs.listPoolSwapsVerbose('9')
+    expect(verbose.hasNext).toStrictEqual(false)
+    expect([...verbose]).toStrictEqual([
+      {
+        id: expect.any(String),
+        txid: expect.stringMatching(/[0-f]{64}/),
+        txno: 1,
+        poolPairId: '9',
+        sort: expect.any(String),
+        fromAmount: '50.00000000',
+        fromTokenId: 1,
+        block: {
+          hash: expect.stringMatching(/[0-f]{64}/),
+          height: expect.any(Number),
+          time: expect.any(Number),
+          medianTime: expect.any(Number)
+        },
+        from: {
+          address: expect.any(String),
+          symbol: 'A',
+          amount: '50.00000000'
+        },
+        to: {
+          address: expect.any(String),
+          amount: '45.71428571',
+          symbol: 'DFI'
+        }
+      },
+      {
+        id: expect.any(String),
+        txid: expect.stringMatching(/[0-f]{64}/),
+        txno: 3,
+        poolPairId: '9',
+        sort: expect.any(String),
+        fromAmount: '25.00000000',
+        fromTokenId: 1,
+        block: {
+          hash: expect.stringMatching(/[0-f]{64}/),
+          height: expect.any(Number),
+          time: expect.any(Number),
+          medianTime: expect.any(Number)
+        },
+        from: {
+          address: expect.any(String),
+          symbol: 'A',
+          amount: '25.00000000'
+        },
+        to: {
+          address: expect.any(String),
+          amount: '39.99999999',
+          symbol: 'DFI'
+        }
+      }
+    ])
 
     const poolPair: PoolPairData = await client.poolpairs.get('9')
     expect(poolPair).toStrictEqual({

--- a/packages/whale-api-client/__tests__/api/poolpairs.test.ts
+++ b/packages/whale-api-client/__tests__/api/poolpairs.test.ts
@@ -3,7 +3,7 @@ import { StubWhaleApiClient } from '../stub.client'
 import { StubService } from '../stub.service'
 import { ApiPagedResponse, WhaleApiClient, WhaleApiException } from '../../src'
 import { addPoolLiquidity, createPoolPair, createToken, getNewAddress, mintTokens, poolSwap } from '@defichain/testing'
-import { PoolPairData, PoolSwap, PoolSwapAggregated, PoolSwapAggregatedInterval } from '../../src/api/poolpairs'
+import { PoolPairData, PoolSwapData, PoolSwapAggregatedData, PoolSwapAggregatedInterval } from '../../src/api/poolpairs'
 import { Testing } from '@defichain/jellyfish-testing'
 
 let container: MasterNodeRegTestContainer
@@ -371,7 +371,7 @@ describe('poolswap', () => {
     await container.generate(1)
     await service.waitForIndexedHeight(height)
 
-    const response: ApiPagedResponse<PoolSwap> = await client.poolpairs.listPoolSwaps('9')
+    const response: ApiPagedResponse<PoolSwapData> = await client.poolpairs.listPoolSwaps('9')
     expect(response.length).toStrictEqual(2)
     expect(response.hasNext).toStrictEqual(false)
     expect(response[0].fromAmount).toStrictEqual('50.00000000')
@@ -594,7 +594,7 @@ describe('poolswap aggregated', () => {
       await service.waitForIndexedHeight(height)
     }
 
-    const dayAggregated: ApiPagedResponse<PoolSwapAggregated> = await client.poolpairs.listPoolSwapAggregates('10', PoolSwapAggregatedInterval.ONE_DAY, 10)
+    const dayAggregated: ApiPagedResponse<PoolSwapAggregatedData> = await client.poolpairs.listPoolSwapAggregates('10', PoolSwapAggregatedInterval.ONE_DAY, 10)
     expect([...dayAggregated]).toStrictEqual([
       {
         aggregated: {
@@ -631,7 +631,7 @@ describe('poolswap aggregated', () => {
 
     ])
 
-    const hourAggregated: ApiPagedResponse<PoolSwapAggregated> = await client.poolpairs.listPoolSwapAggregates('10', PoolSwapAggregatedInterval.ONE_HOUR, 3)
+    const hourAggregated: ApiPagedResponse<PoolSwapAggregatedData> = await client.poolpairs.listPoolSwapAggregates('10', PoolSwapAggregatedInterval.ONE_HOUR, 3)
     expect([...hourAggregated]).toStrictEqual([
       {
         aggregated: {

--- a/packages/whale-api-client/__tests__/api/poolpairs.test.ts
+++ b/packages/whale-api-client/__tests__/api/poolpairs.test.ts
@@ -372,6 +372,9 @@ describe('poolswap', () => {
     await service.waitForIndexedHeight(height)
 
     const response: ApiPagedResponse<PoolSwapData> = await client.poolpairs.listPoolSwaps('9')
+
+    // TODO(fuxingloh):
+    console.log(response)
     expect(response.length).toStrictEqual(2)
     expect(response.hasNext).toStrictEqual(false)
     expect(response[0].fromAmount).toStrictEqual('50.00000000')

--- a/packages/whale-api-client/src/api/poolpairs.ts
+++ b/packages/whale-api-client/src/api/poolpairs.ts
@@ -113,12 +113,27 @@ export interface PoolSwap {
   fromAmount: string
   fromTokenId: number
 
+  /**
+   * To handle for optional value as Whale service might fail to resolve when indexing
+   */
+  from?: PoolSwapFromTo
+  /**
+   * To handle for optional value as Whale service might fail to resolve when indexing
+   */
+  to?: PoolSwapFromTo
+
   block: {
     hash: string
     height: number
     time: number
     medianTime: number
   }
+}
+
+export interface PoolSwapFromTo {
+  address: string
+  amount: string
+  symbol: string
 }
 
 export interface PoolSwapAggregated {

--- a/packages/whale-api-client/src/api/poolpairs.ts
+++ b/packages/whale-api-client/src/api/poolpairs.ts
@@ -42,6 +42,18 @@ export class PoolPairs {
   }
 
   /**
+   * List pool swaps with from/to
+   *
+   * @param {string} id poolpair id
+   * @param {number} [size=10] of PoolSwap to query, max of 20 per page
+   * @param {string} next set of PoolSwap
+   * @return {Promise<ApiPagedResponse<PoolSwapData>>}
+   */
+  async listPoolSwapsVerbose (id: string, size: number = 10, next?: string): Promise<ApiPagedResponse<PoolSwapData>> {
+    return await this.client.requestList('GET', `poolpairs/${id}/swaps/verbose`, size, next)
+  }
+
+  /**
    * List pool swap aggregates
    *
    * @param {string} id poolpair id

--- a/packages/whale-api-client/src/api/poolpairs.ts
+++ b/packages/whale-api-client/src/api/poolpairs.ts
@@ -35,9 +35,9 @@ export class PoolPairs {
    * @param {string} id poolpair id
    * @param {number} size of PoolSwap to query
    * @param {string} next set of PoolSwap
-   * @return {Promise<ApiPagedResponse<PoolSwap>>}
+   * @return {Promise<ApiPagedResponse<PoolSwapData>>}
    */
-  async listPoolSwaps (id: string, size: number = 30, next?: string): Promise<ApiPagedResponse<PoolSwap>> {
+  async listPoolSwaps (id: string, size: number = 30, next?: string): Promise<ApiPagedResponse<PoolSwapData>> {
     return await this.client.requestList('GET', `poolpairs/${id}/swaps`, size, next)
   }
 
@@ -48,9 +48,9 @@ export class PoolPairs {
    * @param {PoolSwapAggregatedInterval} interval interval
    * @param {number} size of PoolSwap to query
    * @param {string} next set of PoolSwap
-   * @return {Promise<ApiPagedResponse<PoolSwapAggregated>>}
+   * @return {Promise<ApiPagedResponse<PoolSwapAggregatedData>>}
    */
-  async listPoolSwapAggregates (id: string, interval: PoolSwapAggregatedInterval, size: number = 30, next?: string): Promise<ApiPagedResponse<PoolSwapAggregated>> {
+  async listPoolSwapAggregates (id: string, interval: PoolSwapAggregatedInterval, size: number = 30, next?: string): Promise<ApiPagedResponse<PoolSwapAggregatedData>> {
     return await this.client.requestList('GET', `poolpairs/${id}/swaps/aggregate/${interval as number}`, size, next)
   }
 }
@@ -103,7 +103,17 @@ export interface PoolPairData {
   }
 }
 
-export interface PoolSwap {
+/**
+ * @deprecated use PoolSwapData instead
+ */
+export type PoolSwap = PoolSwapData
+
+/**
+ * @deprecated use PoolSwapAggregatedData instead
+ */
+export type PoolSwapAggregated = PoolSwapAggregatedData
+
+export interface PoolSwapData {
   id: string
   sort: string
   txid: string
@@ -116,11 +126,11 @@ export interface PoolSwap {
   /**
    * To handle for optional value as Whale service might fail to resolve when indexing
    */
-  from?: PoolSwapFromTo
+  from?: PoolSwapFromToData
   /**
    * To handle for optional value as Whale service might fail to resolve when indexing
    */
-  to?: PoolSwapFromTo
+  to?: PoolSwapFromToData
 
   block: {
     hash: string
@@ -130,13 +140,13 @@ export interface PoolSwap {
   }
 }
 
-export interface PoolSwapFromTo {
+export interface PoolSwapFromToData {
   address: string
   amount: string
   symbol: string
 }
 
-export interface PoolSwapAggregated {
+export interface PoolSwapAggregatedData {
   id: string
   key: string
   bucket: number

--- a/src/module.api/poolpair.controller.ts
+++ b/src/module.api/poolpair.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Get, NotFoundException, Param, ParseIntPipe, Query } from '
 import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
 import { ApiPagedResponse } from '@src/module.api/_core/api.paged.response'
 import { DeFiDCache } from '@src/module.api/cache/defid.cache'
-import { PoolPairData, PoolSwap, PoolSwapAggregated } from '@whale-api-client/api/poolpairs'
+import { PoolPairData, PoolSwapData, PoolSwapAggregatedData } from '@whale-api-client/api/poolpairs'
 import { PaginationQuery } from '@src/module.api/_core/api.query'
 import { PoolPairService } from './poolpair.service'
 import BigNumber from 'bignumber.js'
@@ -83,9 +83,9 @@ export class PoolPairController {
   async listPoolSwaps (
     @Param('id', ParseIntPipe) id: string,
       @Query() query: PaginationQuery
-  ): Promise<ApiPagedResponse<PoolSwap>> {
+  ): Promise<ApiPagedResponse<PoolSwapData>> {
     const items = await this.poolSwapMapper.query(id, query.size, query.next)
-    const mapped: Array<Promise<PoolSwap>> = items.map(async swap => {
+    const mapped: Array<Promise<PoolSwapData>> = items.map(async swap => {
       const fromTo = await this.poolPairService.findSwapFromTo(swap.block.height, swap.txid, swap.txno)
 
       return {
@@ -117,10 +117,10 @@ export class PoolPairController {
     @Param('id', ParseIntPipe) id: string,
       @Param('interval', ParseIntPipe) interval: string,
       @Query() query: PaginationQuery
-  ): Promise<ApiPagedResponse<PoolSwapAggregated>> {
+  ): Promise<ApiPagedResponse<PoolSwapAggregatedData>> {
     const lt = query.next === undefined ? undefined : parseInt(query.next)
     const aggregates = await this.poolSwapAggregatedMapper.query(`${id}-${interval}`, query.size, lt)
-    const mapped: Array<Promise<PoolSwapAggregated>> = aggregates.map(async value => {
+    const mapped: Array<Promise<PoolSwapAggregatedData>> = aggregates.map(async value => {
       return {
         ...value,
         aggregated: {

--- a/src/module.api/poolpair.service.ts
+++ b/src/module.api/poolpair.service.ts
@@ -3,7 +3,7 @@ import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
 import BigNumber from 'bignumber.js'
 import { PoolPairInfo } from '@defichain/jellyfish-api-core/dist/category/poolpair'
 import { SemaphoreCache } from '@src/module.api/cache/semaphore.cache'
-import { PoolPairData, PoolSwapFromTo } from '@whale-api-client/api/poolpairs'
+import { PoolPairData, PoolSwapFromToData } from '@whale-api-client/api/poolpairs'
 import { getBlockSubsidy } from '@src/module.api/subsidy'
 import { BlockMapper } from '@src/module.model/block'
 import { TokenMapper } from '@src/module.model/token'
@@ -217,7 +217,7 @@ export class PoolPairService {
     return value
   }
 
-  public async findSwapFromTo (height: number, txid: string, txno: number): Promise<{ from?: PoolSwapFromTo, to?: PoolSwapFromTo } | undefined> {
+  public async findSwapFromTo (height: number, txid: string, txno: number): Promise<{ from?: PoolSwapFromToData, to?: PoolSwapFromToData } | undefined> {
     const vouts = await this.voutMapper.query(txid, 1)
     const dftx = findPoolSwapDfTx(vouts)
     if (dftx === undefined) {
@@ -394,7 +394,7 @@ function findPoolSwapDfTx (vouts: TransactionVout[]): PoolSwapDfTx | undefined {
   }
 }
 
-function findPoolSwapFromTo (history: AccountHistory, from: boolean): PoolSwapFromTo | undefined {
+function findPoolSwapFromTo (history: AccountHistory, from: boolean): PoolSwapFromToData | undefined {
   for (const amount of history.amounts) {
     const [value, symbol] = amount.split('@')
     const isNegative = value.startsWith('-')

--- a/src/module.api/poolpair.service.ts
+++ b/src/module.api/poolpair.service.ts
@@ -11,12 +11,12 @@ import { PoolSwapAggregated, PoolSwapAggregatedMapper } from '@src/module.model/
 import { PoolSwapAggregatedInterval } from '@src/module.indexer/model/dftx/pool.swap.aggregated'
 import { TransactionVout, TransactionVoutMapper } from '@src/module.model/transaction.vout'
 import { SmartBuffer } from 'smart-buffer'
-import { toOPCodes } from '@defichain/jellyfish-transaction/dist/script/_buffer'
 import {
   CCompositeSwap,
   CompositeSwap,
   CPoolSwap,
   OP_DEFI_TX,
+  toOPCodes,
   PoolSwap as PoolSwapDfTx
 } from '@defichain/jellyfish-transaction'
 import { fromScript } from '@defichain/jellyfish-address'

--- a/src/module.api/poolpair.service.ts
+++ b/src/module.api/poolpair.service.ts
@@ -1,21 +1,36 @@
-import { Injectable, NotFoundException } from '@nestjs/common'
+import { Inject, Injectable, NotFoundException } from '@nestjs/common'
 import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
 import BigNumber from 'bignumber.js'
 import { PoolPairInfo } from '@defichain/jellyfish-api-core/dist/category/poolpair'
 import { SemaphoreCache } from '@src/module.api/cache/semaphore.cache'
-import { PoolPairData } from '@whale-api-client/api/poolpairs'
+import { PoolPairData, PoolSwapFromTo } from '@whale-api-client/api/poolpairs'
 import { getBlockSubsidy } from '@src/module.api/subsidy'
 import { BlockMapper } from '@src/module.model/block'
 import { TokenMapper } from '@src/module.model/token'
 import { PoolSwapAggregated, PoolSwapAggregatedMapper } from '@src/module.model/pool.swap.aggregated'
 import { PoolSwapAggregatedInterval } from '@src/module.indexer/model/dftx/pool.swap.aggregated'
+import { TransactionVout, TransactionVoutMapper } from '@src/module.model/transaction.vout'
+import { SmartBuffer } from 'smart-buffer'
+import { toOPCodes } from '@defichain/jellyfish-transaction/dist/script/_buffer'
+import {
+  CCompositeSwap,
+  CompositeSwap,
+  CPoolSwap,
+  OP_DEFI_TX,
+  PoolSwap as PoolSwapDfTx
+} from '@defichain/jellyfish-transaction'
+import { fromScript } from '@defichain/jellyfish-address'
+import { NetworkName } from '@defichain/jellyfish-network'
+import { AccountHistory } from '@defichain/jellyfish-api-core/dist/category/account'
 
 @Injectable()
 export class PoolPairService {
   constructor (
+    @Inject('NETWORK') protected readonly network: NetworkName,
     protected readonly rpcClient: JsonRpcClient,
     protected readonly cache: SemaphoreCache,
     protected readonly poolSwapAggregatedMapper: PoolSwapAggregatedMapper,
+    protected readonly voutMapper: TransactionVoutMapper,
     protected readonly tokenMapper: TokenMapper,
     protected readonly blockMapper: BlockMapper
   ) {
@@ -202,6 +217,35 @@ export class PoolPairService {
     return value
   }
 
+  public async findSwapFromTo (height: number, txid: string, txno: number): Promise<{ from?: PoolSwapFromTo, to?: PoolSwapFromTo } | undefined> {
+    const vouts = await this.voutMapper.query(txid, 1)
+    const dftx = findPoolSwapDfTx(vouts)
+    if (dftx === undefined) {
+      return undefined
+    }
+
+    const fromAddress = fromScript(dftx.fromScript, this.network)?.address
+    const toAddress = fromScript(dftx.toScript, this.network)?.address
+    if (fromAddress === undefined || toAddress === undefined) {
+      return undefined
+    }
+
+    const histories = await this.getAddressHistory([fromAddress, toAddress], height, txno)
+
+    return {
+      from: findPoolSwapFromTo(histories[fromAddress], true),
+      to: findPoolSwapFromTo(histories[toAddress], false)
+    }
+  }
+
+  private async getAddressHistory (addresses: string[], height: number, txno: number): Promise<{ [address: string]: AccountHistory }> {
+    const histories: { [address: string]: AccountHistory } = {}
+    for (const address of new Set(addresses)) {
+      histories[address] = await this.rpcClient.account.getAccountHistory(address, height, txno)
+    }
+    return histories
+  }
+
   private async getLoanTokenSplits (): Promise<Record<string, number> | undefined> {
     return await this.cache.get<Record<string, number>>('LP_LOAN_TOKEN_SPLITS', async () => {
       const result = await this.rpcClient.masternode.getGov('LP_LOAN_TOKEN_SPLITS')
@@ -323,4 +367,54 @@ export class PoolPairService {
       total: reward.plus(commission).toNumber()
     }
   }
+}
+
+function findPoolSwapDfTx (vouts: TransactionVout[]): PoolSwapDfTx | undefined {
+  const hex = vouts[0].script.hex
+  const buffer = SmartBuffer.fromBuffer(Buffer.from(hex, 'hex'))
+  const stack = toOPCodes(buffer)
+  if (stack.length !== 2 || stack[1].type !== 'OP_DEFI_TX') {
+    return undefined
+  }
+
+  const dftx = (stack[1] as OP_DEFI_TX).tx
+  if (dftx === undefined) {
+    return undefined
+  }
+
+  switch (dftx.name) {
+    case CPoolSwap.OP_NAME:
+      return (dftx.data as PoolSwapDfTx)
+
+    case CCompositeSwap.OP_NAME:
+      return (dftx.data as CompositeSwap).poolSwap
+
+    default:
+      return undefined
+  }
+}
+
+function findPoolSwapFromTo (history: AccountHistory, from: boolean): PoolSwapFromTo | undefined {
+  for (const amount of history.amounts) {
+    const [value, symbol] = amount.split('@')
+    const isNegative = value.startsWith('-')
+
+    if (isNegative && from) {
+      return {
+        address: history.owner,
+        amount: new BigNumber(value).absoluteValue().toFixed(8),
+        symbol: symbol
+      }
+    }
+
+    if (!isNegative && !from) {
+      return {
+        address: history.owner,
+        amount: new BigNumber(value).absoluteValue().toFixed(8),
+        symbol: symbol
+      }
+    }
+  }
+
+  return undefined
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

Included PoolSwap from/to fields for convenience in swap history.

```ts
export interface PoolSwapData {
  /**
   * To handle for optional value as Whale service might fail to resolve when indexing
   */
  from?: PoolSwapFromToData
  /**
   * To handle for optional value as Whale service might fail to resolve when indexing
   */
  to?: PoolSwapFromToData
}

export interface PoolSwapFromToData {
  address: string
  amount: string
  symbol: string
}
```

```ts
/**
 * List pool swaps with from/to
 *
 * @param {string} id poolpair id
 * @param {number} [size=10] of PoolSwap to query, max of 20 per page
 * @param {string} next set of PoolSwap
 * @return {Promise<ApiPagedResponse<PoolSwapData>>}
 */
async listPoolSwapsVerbose (id: string, size: number = 10, next?: string): Promise<ApiPagedResponse<PoolSwapData>> {
  return await this.client.requestList('GET', `poolpairs/${id}/swaps/verbose`, size, next)
}
```