### PR TITLE
feat(controller): token swap pathfinding getallswappabletokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "class-validator": "^0.13.2",
         "defichain": "^2.29.0",
         "graphology": "^0.24.1",
+        "graphology-components": "^1.5.2",
         "graphology-simple-path": "^0.1.2",
         "level": "7.0.0",
         "level-js": "6.0.0",
@@ -8498,6 +8499,46 @@
       },
       "peerDependencies": {
         "graphology-types": ">=0.24.0"
+      }
+    },
+    "node_modules/graphology-components": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/graphology-components/-/graphology-components-1.5.2.tgz",
+      "integrity": "sha512-EW26mjHWX9sggUhZcW1OHsOnEV7lj0nx50mcEHFRNucC3MBoe4yDYtBY8HQqUcGH4FdEq0ukNzzweJGLiy58Tg==",
+      "dependencies": {
+        "graphology-indices": "^0.16.2",
+        "graphology-utils": "^2.1.2"
+      },
+      "peerDependencies": {
+        "graphology-types": ">=0.19.0"
+      }
+    },
+    "node_modules/graphology-components/node_modules/graphology-utils": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/graphology-utils/-/graphology-utils-2.5.1.tgz",
+      "integrity": "sha512-N6zjqvBHgJvulYnwdDgdJoeuhKXZBNm1zedC2asdN+rexfbJylhey/PVT8Bwr8B1aVxKuK+zQqMbQ50kKikjew==",
+      "peerDependencies": {
+        "graphology-types": ">=0.23.0"
+      }
+    },
+    "node_modules/graphology-indices": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/graphology-indices/-/graphology-indices-0.16.6.tgz",
+      "integrity": "sha512-tozTirLb7pd37wULJ5qeIZfZqKuVln/V+bWmUWJ7MmoTU8YkW5dehOkRz2by/O+5MdJ52imqL8LH4+GCd0yEVw==",
+      "dependencies": {
+        "graphology-utils": "^2.4.2",
+        "mnemonist": "^0.39.0"
+      },
+      "peerDependencies": {
+        "graphology-types": ">=0.20.0"
+      }
+    },
+    "node_modules/graphology-indices/node_modules/graphology-utils": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/graphology-utils/-/graphology-utils-2.5.1.tgz",
+      "integrity": "sha512-N6zjqvBHgJvulYnwdDgdJoeuhKXZBNm1zedC2asdN+rexfbJylhey/PVT8Bwr8B1aVxKuK+zQqMbQ50kKikjew==",
+      "peerDependencies": {
+        "graphology-types": ">=0.23.0"
       }
     },
     "node_modules/graphology-simple-path": {
@@ -22826,6 +22867,40 @@
       "requires": {
         "events": "^3.3.0",
         "obliterator": "^2.0.2"
+      }
+    },
+    "graphology-components": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/graphology-components/-/graphology-components-1.5.2.tgz",
+      "integrity": "sha512-EW26mjHWX9sggUhZcW1OHsOnEV7lj0nx50mcEHFRNucC3MBoe4yDYtBY8HQqUcGH4FdEq0ukNzzweJGLiy58Tg==",
+      "requires": {
+        "graphology-indices": "^0.16.2",
+        "graphology-utils": "^2.1.2"
+      },
+      "dependencies": {
+        "graphology-utils": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/graphology-utils/-/graphology-utils-2.5.1.tgz",
+          "integrity": "sha512-N6zjqvBHgJvulYnwdDgdJoeuhKXZBNm1zedC2asdN+rexfbJylhey/PVT8Bwr8B1aVxKuK+zQqMbQ50kKikjew==",
+          "requires": {}
+        }
+      }
+    },
+    "graphology-indices": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/graphology-indices/-/graphology-indices-0.16.6.tgz",
+      "integrity": "sha512-tozTirLb7pd37wULJ5qeIZfZqKuVln/V+bWmUWJ7MmoTU8YkW5dehOkRz2by/O+5MdJ52imqL8LH4+GCd0yEVw==",
+      "requires": {
+        "graphology-utils": "^2.4.2",
+        "mnemonist": "^0.39.0"
+      },
+      "dependencies": {
+        "graphology-utils": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/graphology-utils/-/graphology-utils-2.5.1.tgz",
+          "integrity": "sha512-N6zjqvBHgJvulYnwdDgdJoeuhKXZBNm1zedC2asdN+rexfbJylhey/PVT8Bwr8B1aVxKuK+zQqMbQ50kKikjew==",
+          "requires": {}
+        }
       }
     },
     "graphology-simple-path": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "class-validator": "^0.13.2",
     "defichain": "^2.29.0",
     "graphology": "^0.24.1",
+    "graphology-components": "^1.5.2",
     "graphology-simple-path": "^0.1.2",
     "level": "7.0.0",
     "level-js": "6.0.0",

--- a/packages/whale-api-client/src/api/poolpairs.ts
+++ b/packages/whale-api-client/src/api/poolpairs.ts
@@ -182,44 +182,36 @@ export enum PoolSwapAggregatedInterval {
   ONE_DAY = ONE_HOUR * 24
 }
 
+export interface AllSwappableTokensResult {
+  fromToken: TokenIdentifier
+  swappableTokens: TokenIdentifier[]
+}
+
 export interface BestSwapPathResult {
-  fromToken: {
-    id: string
-    symbol: string
-  }
-  toToken: {
-    id: string
-    symbol: string
-  }
+  fromToken: TokenIdentifier
+  toToken: TokenIdentifier
   bestPath: SwapPathPoolPair[]
   estimatedReturn: string
 }
 
 export interface SwapPathsResult {
-  fromToken: {
-    id: string
-    symbol: string
-  }
-  toToken: {
-    id: string
-    symbol: string
-  }
+  fromToken: TokenIdentifier
+  toToken: TokenIdentifier
   paths: SwapPathPoolPair[][]
 }
 
 export interface SwapPathPoolPair {
   poolPairId: string
   symbol: string
-  tokenA: {
-    id: string
-    symbol: string
-  }
-  tokenB: {
-    id: string
-    symbol: string
-  }
+  tokenA: TokenIdentifier
+  tokenB: TokenIdentifier
   priceRatio: {
     ab: string
     ba: string
   }
+}
+
+export interface TokenIdentifier {
+  id: string
+  symbol: string
 }

--- a/packages/whale-api-client/src/api/poolpairs.ts
+++ b/packages/whale-api-client/src/api/poolpairs.ts
@@ -214,4 +214,5 @@ export interface SwapPathPoolPair {
 export interface TokenIdentifier {
   id: string
   symbol: string
+  displaySymbol: string
 }

--- a/src/module.api/poolpair.controller.e2e.ts
+++ b/src/module.api/poolpair.controller.e2e.ts
@@ -648,3 +648,37 @@ describe('get all paths', () => {
     await expect(controller.listPaths('-1', '100')).rejects.toThrowError('Unable to find token -1')
   })
 })
+
+describe('get list swappable tokens', () => {
+  it('should list correct swappable tokens', async () => {
+    const result = await controller.listSwappableTokens('1') // A
+    expect(result).toStrictEqual({
+      fromToken: { id: '1', symbol: 'A' },
+      swappableTokens: [
+        { id: '1', symbol: 'A' },
+        { id: '7', symbol: 'G' },
+        { id: '0', symbol: 'DFI' },
+        { id: '24', symbol: 'USDT' },
+        { id: '6', symbol: 'F' },
+        { id: '5', symbol: 'E' },
+        { id: '4', symbol: 'D' },
+        { id: '3', symbol: 'C' },
+        { id: '2', symbol: 'B' }
+      ]
+    })
+  })
+
+  it('should list no tokens for token that is not swappable with any', async () => {
+    const result = await controller.listSwappableTokens('8') // H
+    expect(result).toStrictEqual({
+      fromToken: { id: '8', symbol: 'H' },
+      swappableTokens: []
+    })
+  })
+
+  it('should throw error for invalid / non-existent tokenId', async () => {
+    await expect(controller.listSwappableTokens('-1')).rejects.toThrowError('Unable to find token -1')
+    await expect(controller.listSwappableTokens('100')).rejects.toThrowError('Unable to find token 100')
+    await expect(controller.listSwappableTokens('a')).rejects.toThrowError('Unable to find token a')
+  })
+})

--- a/src/module.api/poolpair.controller.e2e.ts
+++ b/src/module.api/poolpair.controller.e2e.ts
@@ -655,7 +655,6 @@ describe('get list swappable tokens', () => {
     expect(result).toStrictEqual({
       fromToken: { id: '1', symbol: 'A' },
       swappableTokens: [
-        { id: '1', symbol: 'A' },
         { id: '7', symbol: 'G' },
         { id: '0', symbol: 'DFI' },
         { id: '24', symbol: 'USDT' },

--- a/src/module.api/poolpair.controller.e2e.ts
+++ b/src/module.api/poolpair.controller.e2e.ts
@@ -283,19 +283,21 @@ describe('get best path', () => {
     expect(paths1).toStrictEqual({
       fromToken: {
         id: '1',
-        symbol: 'A'
+        symbol: 'A',
+        displaySymbol: 'dA'
       },
       toToken: {
         id: '0',
-        symbol: 'DFI'
+        symbol: 'DFI',
+        displaySymbol: 'DFI'
       },
       bestPath: [
         {
           symbol: 'A-DFI',
           poolPairId: '13',
           priceRatio: { ab: '0.50000000', ba: '2.00000000' },
-          tokenA: { id: '1', symbol: 'A' },
-          tokenB: { id: '0', symbol: 'DFI' }
+          tokenA: { id: '1', symbol: 'A', displaySymbol: 'dA' },
+          tokenB: { id: '0', symbol: 'DFI', displaySymbol: 'DFI' }
         }
       ],
       estimatedReturn: '2.00000000'
@@ -308,26 +310,28 @@ describe('get best path', () => {
     expect(response).toStrictEqual({
       fromToken: {
         id: '1',
-        symbol: 'A'
+        symbol: 'A',
+        displaySymbol: 'dA'
       },
       toToken: {
         id: '3',
-        symbol: 'C'
+        symbol: 'C',
+        displaySymbol: 'dC'
       },
       bestPath: [
         {
           symbol: 'A-DFI',
           poolPairId: '13',
           priceRatio: { ab: '0.50000000', ba: '2.00000000' },
-          tokenA: { id: '1', symbol: 'A' },
-          tokenB: { id: '0', symbol: 'DFI' }
+          tokenA: { id: '1', symbol: 'A', displaySymbol: 'dA' },
+          tokenB: { id: '0', symbol: 'DFI', displaySymbol: 'DFI' }
         },
         {
           symbol: 'C-DFI',
           poolPairId: '15',
           priceRatio: { ab: '0.25000000', ba: '4.00000000' },
-          tokenA: { id: '3', symbol: 'C' },
-          tokenB: { id: '0', symbol: 'DFI' }
+          tokenA: { id: '3', symbol: 'C', displaySymbol: 'dC' },
+          tokenB: { id: '0', symbol: 'DFI', displaySymbol: 'DFI' }
         }
       ],
       estimatedReturn: '0.50000000'
@@ -339,33 +343,35 @@ describe('get best path', () => {
     expect(response).toStrictEqual({
       fromToken: {
         id: '7',
-        symbol: 'G'
+        symbol: 'G',
+        displaySymbol: 'dG'
       },
       toToken: {
         id: '3',
-        symbol: 'C'
+        symbol: 'C',
+        displaySymbol: 'dC'
       },
       bestPath: [
         {
           symbol: 'G-A',
           poolPairId: '19',
           priceRatio: { ab: '0.00000000', ba: '0.00000000' },
-          tokenA: { id: '7', symbol: 'G' },
-          tokenB: { id: '1', symbol: 'A' }
+          tokenA: { id: '7', symbol: 'G', displaySymbol: 'dG' },
+          tokenB: { id: '1', symbol: 'A', displaySymbol: 'dA' }
         },
         {
           symbol: 'A-DFI',
           poolPairId: '13',
           priceRatio: { ab: '0.50000000', ba: '2.00000000' },
-          tokenA: { id: '1', symbol: 'A' },
-          tokenB: { id: '0', symbol: 'DFI' }
+          tokenA: { id: '1', symbol: 'A', displaySymbol: 'dA' },
+          tokenB: { id: '0', symbol: 'DFI', displaySymbol: 'DFI' }
         },
         {
           symbol: 'C-DFI',
           poolPairId: '15',
           priceRatio: { ab: '0.25000000', ba: '4.00000000' },
-          tokenA: { id: '3', symbol: 'C' },
-          tokenB: { id: '0', symbol: 'DFI' }
+          tokenA: { id: '3', symbol: 'C', displaySymbol: 'dC' },
+          tokenB: { id: '0', symbol: 'DFI', displaySymbol: 'DFI' }
         }
       ],
       estimatedReturn: '0.00000000'
@@ -379,26 +385,28 @@ describe('get best path', () => {
     expect(response).toStrictEqual({
       fromToken: {
         id: '10',
-        symbol: 'J'
+        symbol: 'J',
+        displaySymbol: 'dJ'
       },
       toToken: {
         id: '11',
-        symbol: 'K'
+        symbol: 'K',
+        displaySymbol: 'dK'
       },
       bestPath: [
         {
           symbol: 'J-L',
           poolPairId: '22',
           priceRatio: { ab: '0.50000000', ba: '2.00000000' },
-          tokenA: { id: '10', symbol: 'J' },
-          tokenB: { id: '12', symbol: 'L' }
+          tokenA: { id: '10', symbol: 'J', displaySymbol: 'dJ' },
+          tokenB: { id: '12', symbol: 'L', displaySymbol: 'dL' }
         },
         {
           symbol: 'L-K',
           poolPairId: '23',
           priceRatio: { ab: '0.25000000', ba: '4.00000000' },
-          tokenA: { id: '12', symbol: 'L' },
-          tokenB: { id: '11', symbol: 'K' }
+          tokenA: { id: '12', symbol: 'L', displaySymbol: 'dL' },
+          tokenB: { id: '11', symbol: 'K', displaySymbol: 'dK' }
         }
       ],
       estimatedReturn: '8.00000000'
@@ -410,11 +418,13 @@ describe('get best path', () => {
     expect(response).toStrictEqual({
       fromToken: {
         id: '8',
-        symbol: 'H'
+        symbol: 'H',
+        displaySymbol: 'dH'
       },
       toToken: {
         id: '1',
-        symbol: 'A'
+        symbol: 'A',
+        displaySymbol: 'dA'
       },
       bestPath: [],
       estimatedReturn: '0'
@@ -437,19 +447,21 @@ describe('get all paths', () => {
     expect(paths1).toStrictEqual({
       fromToken: {
         id: '1',
-        symbol: 'A'
+        symbol: 'A',
+        displaySymbol: 'dA'
       },
       toToken: {
         id: '0',
-        symbol: 'DFI'
+        symbol: 'DFI',
+        displaySymbol: 'DFI'
       },
       paths: [
         [
           {
-            poolPairId: '13',
             symbol: 'A-DFI',
-            tokenA: { id: '1', symbol: 'A' },
-            tokenB: { id: '0', symbol: 'DFI' },
+            poolPairId: '13',
+            tokenA: { id: '1', symbol: 'A', displaySymbol: 'dA' },
+            tokenB: { id: '0', symbol: 'DFI', displaySymbol: 'DFI' },
             priceRatio: { ab: '0.50000000', ba: '2.00000000' }
           }
         ]
@@ -463,11 +475,13 @@ describe('get all paths', () => {
     expect(response).toStrictEqual({
       fromToken: {
         id: '1',
-        symbol: 'A'
+        symbol: 'A',
+        displaySymbol: 'dA'
       },
       toToken: {
         id: '3',
-        symbol: 'C'
+        symbol: 'C',
+        displaySymbol: 'dC'
       },
       paths: [
         [
@@ -475,15 +489,15 @@ describe('get all paths', () => {
             symbol: 'A-DFI',
             poolPairId: '13',
             priceRatio: { ab: '0.50000000', ba: '2.00000000' },
-            tokenA: { id: '1', symbol: 'A' },
-            tokenB: { id: '0', symbol: 'DFI' }
+            tokenA: { id: '1', symbol: 'A', displaySymbol: 'dA' },
+            tokenB: { id: '0', symbol: 'DFI', displaySymbol: 'DFI' }
           },
           {
             symbol: 'C-DFI',
             poolPairId: '15',
             priceRatio: { ab: '0.25000000', ba: '4.00000000' },
-            tokenA: { id: '3', symbol: 'C' },
-            tokenB: { id: '0', symbol: 'DFI' }
+            tokenA: { id: '3', symbol: 'C', displaySymbol: 'dC' },
+            tokenB: { id: '0', symbol: 'DFI', displaySymbol: 'DFI' }
           }
         ]
       ]
@@ -495,11 +509,13 @@ describe('get all paths', () => {
     expect(response).toStrictEqual({
       fromToken: {
         id: '7',
-        symbol: 'G'
+        symbol: 'G',
+        displaySymbol: 'dG'
       },
       toToken: {
         id: '3',
-        symbol: 'C'
+        symbol: 'C',
+        displaySymbol: 'dC'
       },
       paths: [
         [
@@ -507,22 +523,22 @@ describe('get all paths', () => {
             symbol: 'G-A',
             poolPairId: '19',
             priceRatio: { ab: '0.00000000', ba: '0.00000000' },
-            tokenA: { id: '7', symbol: 'G' },
-            tokenB: { id: '1', symbol: 'A' }
+            tokenA: { id: '7', symbol: 'G', displaySymbol: 'dG' },
+            tokenB: { id: '1', symbol: 'A', displaySymbol: 'dA' }
           },
           {
             symbol: 'A-DFI',
             poolPairId: '13',
             priceRatio: { ab: '0.50000000', ba: '2.00000000' },
-            tokenA: { id: '1', symbol: 'A' },
-            tokenB: { id: '0', symbol: 'DFI' }
+            tokenA: { id: '1', symbol: 'A', displaySymbol: 'dA' },
+            tokenB: { id: '0', symbol: 'DFI', displaySymbol: 'DFI' }
           },
           {
             symbol: 'C-DFI',
             poolPairId: '15',
             priceRatio: { ab: '0.25000000', ba: '4.00000000' },
-            tokenA: { id: '3', symbol: 'C' },
-            tokenB: { id: '0', symbol: 'DFI' }
+            tokenA: { id: '3', symbol: 'C', displaySymbol: 'dC' },
+            tokenB: { id: '0', symbol: 'DFI', displaySymbol: 'DFI' }
           }
         ]
       ]
@@ -534,11 +550,13 @@ describe('get all paths', () => {
     expect(response).toStrictEqual({
       fromToken: {
         id: '9',
-        symbol: 'I'
+        symbol: 'I',
+        displaySymbol: 'dI'
       },
       toToken: {
         id: '11',
-        symbol: 'K'
+        symbol: 'K',
+        displaySymbol: 'dK'
       },
       paths: [
         [
@@ -546,22 +564,22 @@ describe('get all paths', () => {
             symbol: 'I-J',
             poolPairId: '20',
             priceRatio: { ab: '0.00000000', ba: '0.00000000' },
-            tokenA: { id: '9', symbol: 'I' },
-            tokenB: { id: '10', symbol: 'J' }
+            tokenA: { id: '9', symbol: 'I', displaySymbol: 'dI' },
+            tokenB: { id: '10', symbol: 'J', displaySymbol: 'dJ' }
           },
           {
             symbol: 'J-L',
             poolPairId: '22',
             priceRatio: { ab: '0.50000000', ba: '2.00000000' },
-            tokenA: { id: '10', symbol: 'J' },
-            tokenB: { id: '12', symbol: 'L' }
+            tokenA: { id: '10', symbol: 'J', displaySymbol: 'dJ' },
+            tokenB: { id: '12', symbol: 'L', displaySymbol: 'dL' }
           },
           {
             symbol: 'L-K',
             poolPairId: '23',
             priceRatio: { ab: '0.25000000', ba: '4.00000000' },
-            tokenA: { id: '12', symbol: 'L' },
-            tokenB: { id: '11', symbol: 'K' }
+            tokenA: { id: '12', symbol: 'L', displaySymbol: 'dL' },
+            tokenB: { id: '11', symbol: 'K', displaySymbol: 'dK' }
           }
         ],
         [
@@ -569,15 +587,15 @@ describe('get all paths', () => {
             symbol: 'I-J',
             poolPairId: '20',
             priceRatio: { ab: '0.00000000', ba: '0.00000000' },
-            tokenA: { id: '9', symbol: 'I' },
-            tokenB: { id: '10', symbol: 'J' }
+            tokenA: { id: '9', symbol: 'I', displaySymbol: 'dI' },
+            tokenB: { id: '10', symbol: 'J', displaySymbol: 'dJ' }
           },
           {
             symbol: 'J-K',
             poolPairId: '21',
             priceRatio: { ab: '0.14285714', ba: '7.00000000' },
-            tokenA: { id: '10', symbol: 'J' },
-            tokenB: { id: '11', symbol: 'K' }
+            tokenA: { id: '10', symbol: 'J', displaySymbol: 'dJ' },
+            tokenB: { id: '11', symbol: 'K', displaySymbol: 'dK' }
           }
         ]
       ]
@@ -589,11 +607,13 @@ describe('get all paths', () => {
     expect(response).toStrictEqual({
       fromToken: {
         id: '10',
-        symbol: 'J'
+        symbol: 'J',
+        displaySymbol: 'dJ'
       },
       toToken: {
         id: '11',
-        symbol: 'K'
+        symbol: 'K',
+        displaySymbol: 'dK'
       },
       paths: [
         [
@@ -601,15 +621,15 @@ describe('get all paths', () => {
             symbol: 'J-L',
             poolPairId: '22',
             priceRatio: { ab: '0.50000000', ba: '2.00000000' },
-            tokenA: { id: '10', symbol: 'J' },
-            tokenB: { id: '12', symbol: 'L' }
+            tokenA: { id: '10', symbol: 'J', displaySymbol: 'dJ' },
+            tokenB: { id: '12', symbol: 'L', displaySymbol: 'dL' }
           },
           {
             symbol: 'L-K',
             poolPairId: '23',
             priceRatio: { ab: '0.25000000', ba: '4.00000000' },
-            tokenA: { id: '12', symbol: 'L' },
-            tokenB: { id: '11', symbol: 'K' }
+            tokenA: { id: '12', symbol: 'L', displaySymbol: 'dL' },
+            tokenB: { id: '11', symbol: 'K', displaySymbol: 'dK' }
           }
         ],
         [
@@ -617,8 +637,8 @@ describe('get all paths', () => {
             symbol: 'J-K',
             poolPairId: '21',
             priceRatio: { ab: '0.14285714', ba: '7.00000000' },
-            tokenA: { id: '10', symbol: 'J' },
-            tokenB: { id: '11', symbol: 'K' }
+            tokenA: { id: '10', symbol: 'J', displaySymbol: 'dJ' },
+            tokenB: { id: '11', symbol: 'K', displaySymbol: 'dK' }
           }
         ]
       ]
@@ -630,11 +650,13 @@ describe('get all paths', () => {
     expect(response).toStrictEqual({
       fromToken: {
         id: '8',
-        symbol: 'H'
+        symbol: 'H',
+        displaySymbol: 'dH'
       },
       toToken: {
         id: '1',
-        symbol: 'A'
+        symbol: 'A',
+        displaySymbol: 'dA'
       },
       paths: []
     })
@@ -653,16 +675,16 @@ describe('get list swappable tokens', () => {
   it('should list correct swappable tokens', async () => {
     const result = await controller.listSwappableTokens('1') // A
     expect(result).toStrictEqual({
-      fromToken: { id: '1', symbol: 'A' },
+      fromToken: { id: '1', symbol: 'A', displaySymbol: 'dA' },
       swappableTokens: [
-        { id: '7', symbol: 'G' },
-        { id: '0', symbol: 'DFI' },
-        { id: '24', symbol: 'USDT' },
-        { id: '6', symbol: 'F' },
-        { id: '5', symbol: 'E' },
-        { id: '4', symbol: 'D' },
-        { id: '3', symbol: 'C' },
-        { id: '2', symbol: 'B' }
+        { id: '7', symbol: 'G', displaySymbol: 'dG' },
+        { id: '0', symbol: 'DFI', displaySymbol: 'DFI' },
+        { id: '24', symbol: 'USDT', displaySymbol: 'dUSDT' },
+        { id: '6', symbol: 'F', displaySymbol: 'dF' },
+        { id: '5', symbol: 'E', displaySymbol: 'dE' },
+        { id: '4', symbol: 'D', displaySymbol: 'dD' },
+        { id: '3', symbol: 'C', displaySymbol: 'dC' },
+        { id: '2', symbol: 'B', displaySymbol: 'dB' }
       ]
     })
   })
@@ -670,7 +692,7 @@ describe('get list swappable tokens', () => {
   it('should list no tokens for token that is not swappable with any', async () => {
     const result = await controller.listSwappableTokens('8') // H
     expect(result).toStrictEqual({
-      fromToken: { id: '8', symbol: 'H' },
+      fromToken: { id: '8', symbol: 'H', displaySymbol: 'dH' },
       swappableTokens: []
     })
   })

--- a/src/module.api/poolpair.controller.ts
+++ b/src/module.api/poolpair.controller.ts
@@ -2,7 +2,14 @@ import { Controller, Get, NotFoundException, Param, ParseIntPipe, Query } from '
 import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
 import { ApiPagedResponse } from '@src/module.api/_core/api.paged.response'
 import { DeFiDCache } from '@src/module.api/cache/defid.cache'
-import { BestSwapPathResult, PoolPairData, PoolSwapAggregatedData, PoolSwapData, SwapPathsResult } from '@whale-api-client/api/poolpairs'
+import {
+  AllSwappableTokensResult,
+  BestSwapPathResult,
+  PoolPairData,
+  PoolSwapAggregatedData,
+  PoolSwapData,
+  SwapPathsResult
+} from '@whale-api-client/api/poolpairs'
 import { PaginationQuery } from '@src/module.api/_core/api.query'
 import { PoolPairService, PoolSwapPathFindingService } from './poolpair.service'
 import BigNumber from 'bignumber.js'
@@ -150,6 +157,13 @@ export class PoolPairController {
     return ApiPagedResponse.of(result, query.size, item => {
       return `${item.bucket}`
     })
+  }
+
+  @Get('/paths/swappable/:tokenId')
+  async listSwappableTokens (
+    @Param('tokenId', ParseIntPipe) tokenId: string
+  ): Promise<AllSwappableTokensResult> {
+    return await this.poolSwapPathService.getAllSwappableTokens(tokenId)
   }
 
   @Get('/paths/from/:fromTokenId/to/:toTokenId')

--- a/src/module.api/poolpair.service.ts
+++ b/src/module.api/poolpair.service.ts
@@ -645,7 +645,10 @@ export class PoolSwapPathFindingService {
 
       // index each token to their swappable tokens
       for (const token of tokens) {
-        this.tokensToSwappableTokens.set(token.id, tokens)
+        this.tokensToSwappableTokens.set(
+          token.id,
+          tokens.filter(tk => tk.id !== token.id) // exclude tokens from their own 'swappables' list
+        )
       }
     }
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
/kind feature

#### What this PR does / why we need it:
- Implements `/poolpairs/paths/swappable/1` endpoint to retrieve all swappable tokens given a token
- To merge after #822 

Returns response:
`poolswap/paths/swappable/1`
```javascript
{
  fromToken: { id: '1', symbol: 'A' },
  swappableTokens: [
    { id: '7', symbol: 'G' },
    { id: '0', symbol: 'DFI' },
    { id: '24', symbol: 'USDT' },
    { id: '6', symbol: 'F' },
    { id: '5', symbol: 'E' },
    { id: '4', symbol: 'D' },
    { id: '3', symbol: 'C' },
    { id: '2', symbol: 'B' }
  ]
}
```

#### Which issue(s) does this PR fixes?:
Fixes part of #809 
