### PR TITLE
feat(swap-pathfinding): glue api client with swap path finding endpoints

### DIFF
--- a/packages/whale-api-client/src/api/poolpairs.ts
+++ b/packages/whale-api-client/src/api/poolpairs.ts
@@ -67,17 +67,30 @@ export class PoolPairs {
   }
 
   /**
-   * List all swappable tokens for a given token
+   * Get all swappable tokens for a given token
    * @param {string} tokenId
+   * @return {Promise<AllSwappableTokensResult>}
    */
   async getSwappableTokens (tokenId: string): Promise<AllSwappableTokensResult> {
     return await this.client.requestData('GET', `poolpairs/paths/swappable/${tokenId}`)
   }
 
-  async getBestPath (fromTokenId: string, toTokenId: string): Promise<SwapPathsResult> {
+  /**
+   * Get the best (estimated) swap path from one token to another
+   * @param {string} fromTokenId
+   * @param {string} toTokenId
+   * @return {Promise<BestSwapPathResult>}
+   */
+  async getBestPath (fromTokenId: string, toTokenId: string): Promise<BestSwapPathResult> {
     return await this.client.requestData('GET', `poolpairs/paths/best/from/${fromTokenId}/to/${toTokenId}`)
   }
 
+  /**
+   * Get all possible swap paths from one token to another
+   * @param {string} fromTokenId
+   * @param {string} toTokenId
+   * @return {Promise<SwapPathsResult>}
+   */
   async getAllPaths (fromTokenId: string, toTokenId: string): Promise<SwapPathsResult> {
     return await this.client.requestData('GET', `poolpairs/paths/from/${fromTokenId}/to/${toTokenId}`)
   }

--- a/packages/whale-api-client/src/api/poolpairs.ts
+++ b/packages/whale-api-client/src/api/poolpairs.ts
@@ -65,6 +65,22 @@ export class PoolPairs {
   async listPoolSwapAggregates (id: string, interval: PoolSwapAggregatedInterval, size: number = 30, next?: string): Promise<ApiPagedResponse<PoolSwapAggregatedData>> {
     return await this.client.requestList('GET', `poolpairs/${id}/swaps/aggregate/${interval as number}`, size, next)
   }
+
+  /**
+   * List all swappable tokens for a given token
+   * @param {string} tokenId
+   */
+  async getSwappableTokens (tokenId: string): Promise<AllSwappableTokensResult> {
+    return await this.client.requestData('GET', `poolpairs/paths/swappable/${tokenId}`)
+  }
+
+  async getBestPath (fromTokenId: string, toTokenId: string): Promise<SwapPathsResult> {
+    return await this.client.requestData('GET', `poolpairs/paths/best/from/${fromTokenId}/to/${toTokenId}`)
+  }
+
+  async getAllPaths (fromTokenId: string, toTokenId: string): Promise<SwapPathsResult> {
+    return await this.client.requestData('GET', `poolpairs/paths/from/${fromTokenId}/to/${toTokenId}`)
+  }
 }
 
 export interface PoolPairData {

--- a/src/module.api/pipes/api.validation.pipe.ts
+++ b/src/module.api/pipes/api.validation.pipe.ts
@@ -1,4 +1,4 @@
-import { HttpStatus, ValidationError, ValidationPipe } from '@nestjs/common'
+import { ArgumentMetadata, HttpStatus, ParseIntPipe, ValidationError, ValidationPipe } from '@nestjs/common'
 import { ApiErrorType, ApiException } from '@src/module.api/_core/api.error'
 
 export class ApiValidationPipe extends ValidationPipe {
@@ -54,5 +54,14 @@ export class ValidationApiException extends ApiException {
       constraints: mapConstraints(),
       properties: mapProperties()
     }
+  }
+}
+
+export class StringIsIntegerPipe extends ValidationPipe {
+  parseIntPipe = new ParseIntPipe()
+
+  async transform (value: string, metadata: ArgumentMetadata): Promise<string> {
+    await this.parseIntPipe.transform(value, metadata) // throws error if value is not a numeric string
+    return value
   }
 }

--- a/src/module.api/poolpair.controller.ts
+++ b/src/module.api/poolpair.controller.ts
@@ -17,6 +17,7 @@ import { PoolPairInfo } from '@defichain/jellyfish-api-core/dist/category/poolpa
 import { parseDATSymbol } from '@src/module.api/token.controller'
 import { PoolSwapMapper } from '@src/module.model/pool.swap'
 import { PoolSwapAggregatedMapper } from '@src/module.model/pool.swap.aggregated'
+import { StringIsIntegerPipe } from '@src/module.api/pipes/api.validation.pipe'
 
 @Controller('/poolpairs')
 export class PoolPairController {
@@ -161,23 +162,23 @@ export class PoolPairController {
 
   @Get('/paths/swappable/:tokenId')
   async listSwappableTokens (
-    @Param('tokenId', ParseIntPipe) tokenId: string
+    @Param('tokenId', StringIsIntegerPipe) tokenId: string
   ): Promise<AllSwappableTokensResult> {
     return await this.poolSwapPathService.getAllSwappableTokens(tokenId)
   }
 
   @Get('/paths/from/:fromTokenId/to/:toTokenId')
   async listPaths (
-    @Param('fromTokenId', ParseIntPipe) fromTokenId: string,
-      @Param('toTokenId', ParseIntPipe) toTokenId: string
+    @Param('fromTokenId', StringIsIntegerPipe) fromTokenId: string,
+      @Param('toTokenId', StringIsIntegerPipe) toTokenId: string
   ): Promise<SwapPathsResult> {
     return await this.poolSwapPathService.getAllSwapPaths(fromTokenId, toTokenId)
   }
 
   @Get('/paths/best/from/:fromTokenId/to/:toTokenId')
   async getBestPath (
-    @Param('fromTokenId', ParseIntPipe) fromTokenId: string,
-      @Param('toTokenId', ParseIntPipe) toTokenId: string
+    @Param('fromTokenId', StringIsIntegerPipe) fromTokenId: string,
+      @Param('toTokenId', StringIsIntegerPipe) toTokenId: string
   ): Promise<BestSwapPathResult> {
     return await this.poolSwapPathService.getBestPath(fromTokenId, toTokenId)
   }


### PR DESCRIPTION

<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
/kind feature

#### What this PR does / why we need it:
Exposes functionality via whale-api-client that was added in:
- #822 
- #849

#### Which issue(s) does this PR fixes?:
Fixes part of https://github.com/DeFiCh/whale/issues/809

#### Additional comments?:
- changed ParseIntPipe to StringIsInteger validation pipe so a String value is passed to the controller instead of a Number (all places using ParseIntPipe but expecting a string are lulled into a false sense of security)