### PR TITLE
fix(poolpairs/prices): skip non-DAT tokens as only DAT tokens can be traded on DEX

### DIFF
--- a/src/module.api/poolpair.prices.service.ts
+++ b/src/module.api/poolpair.prices.service.ts
@@ -82,8 +82,8 @@ export class PoolPairPricesService {
     const allTokenInfo: TokensBySymbol = {}
 
     for (const token of tokens) {
-      // Skip LP tokens
-      if (token.isLPS) {
+      // Skip LP tokens and non-DAT tokens
+      if (token.isLPS || !token.isDAT) {
         continue
       }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
/kind fix

#### What this PR does / why we need it:
Only include DAT tokens in `poolpairs/dexprices` result as only DAT tokens can be traded on DEX.

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #880
