### PR TITLE
fix(poolpair/paths): make defidcache.getpoolpairinfo rely on 1m cached list instead of 10m cache

### DIFF
--- a/src/module.api/cache/defid.cache.spec.ts
+++ b/src/module.api/cache/defid.cache.spec.ts
@@ -15,7 +15,7 @@ let cache: Cache
 let defiCache: DeFiDCache
 let testingModule: TestingModule
 
-describe('getPoolPairInfo', () => {
+describe.skip('getPoolPairInfo', () => {
   beforeAll(async () => {
     await container.start()
     await container.waitForReady()

--- a/src/module.api/cache/defid.cache.spec.ts
+++ b/src/module.api/cache/defid.cache.spec.ts
@@ -15,7 +15,7 @@ let cache: Cache
 let defiCache: DeFiDCache
 let testingModule: TestingModule
 
-describe.skip('getPoolPairInfo', () => {
+describe('getPoolPairInfo', () => {
   beforeAll(async () => {
     await container.start()
     await container.waitForReady()

--- a/src/module.api/cache/defid.cache.ts
+++ b/src/module.api/cache/defid.cache.ts
@@ -3,7 +3,7 @@ import { Cache } from 'cache-manager'
 import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
 import { TokenInfo, TokenResult } from '@defichain/jellyfish-api-core/dist/category/token'
 import { CachePrefix, GlobalCache } from '@src/module.api/cache/global.cache'
-import { PoolPairInfo } from '@defichain/jellyfish-api-core/dist/category/poolpair'
+import { PoolPairInfo, PoolPairsResult } from '@defichain/jellyfish-api-core/dist/category/poolpair'
 import { GetLoanSchemeResult } from '@defichain/jellyfish-api-core/dist/category/loan'
 
 @Injectable()
@@ -58,22 +58,47 @@ export class DeFiDCache extends GlobalCache {
   }
 
   async getPoolPairInfo (id: string): Promise<PoolPairInfo | undefined> {
-    return await this.get<PoolPairInfo>(CachePrefix.POOL_PAIR_INFO, id, this.fetchPoolPairInfo.bind(this))
+    const poolPairsById = await this.listPoolPairs()
+    if (poolPairsById === undefined) {
+      return undefined
+    }
+    return poolPairsById[id]
   }
 
-  private async fetchPoolPairInfo (id: string): Promise<PoolPairInfo | undefined> {
-    try {
-      const result = await this.rpcClient.poolpair.getPoolPair(id)
-      if (result[id] === undefined) {
-        return undefined
+  async listPoolPairs (): Promise<PoolPairsResult | undefined> {
+    return await this.get<PoolPairsResult>(CachePrefix.POOL_PAIRS, '*', this.fetchPoolPairs.bind(this),
+      {
+        ttl: 60
       }
-      return result[id]
-    } catch (err: any) {
-      /* istanbul ignore else */
-      if (err?.payload?.message === 'Pool not found') {
-        return undefined
+    )
+  }
+
+  private async fetchPoolPairs (): Promise<PoolPairsResult> {
+    const result: PoolPairsResult = {}
+    let next: number | null = 0
+
+    // Follow pagination chain until the end
+    while (true) {
+      const poolPairs: PoolPairsResult = await this.rpcClient.poolpair.listPoolPairs({
+        start: next,
+        including_start: next === 0, // only for the first
+        limit: 1000
+      }, true)
+
+      const poolPairIds: string[] = Object.keys(poolPairs)
+
+      // At the end of pagination chain - no more data to fetch
+      if (poolPairIds.length === 0) {
+        break
       }
-      throw err
+
+      // Add to results
+      for (const poolPairId of poolPairIds) {
+        result[poolPairId] = poolPairs[poolPairId]
+      }
+      next = Number(poolPairIds[poolPairIds.length - 1])
     }
+
+    return result
   }
 }

--- a/src/module.api/cache/global.cache.ts
+++ b/src/module.api/cache/global.cache.ts
@@ -9,7 +9,8 @@ export enum CachePrefix {
   TOKEN_INFO = 0,
   POOL_PAIR_INFO = 1,
   TOKEN_INFO_SYMBOL = 2,
-  LOAN_SCHEME_INFO = 3
+  LOAN_SCHEME_INFO = 3,
+  POOL_PAIRS = 4,
 }
 
 export class GlobalCache {

--- a/src/module.api/poolswap.pathfinding.service.ts
+++ b/src/module.api/poolswap.pathfinding.service.ts
@@ -206,7 +206,7 @@ export class PoolSwapPathFindingService {
   }
 
   private async getPoolPairInfo (poolPairId: string): Promise<PoolPairInfo> {
-    const poolPair = await this.deFiDCache.getPoolPairInfo(poolPairId)
+    const poolPair = await this.deFiDCache.getPoolPairInfoFromPoolPairs(poolPairId)
     if (poolPair === undefined) {
       throw new NotFoundException(`Unable to find token ${poolPairId}`)
     }


### PR DESCRIPTION
#### What kind of PR is this?:
/kind fix

#### What this PR does / why we need it:
- Fixes price updates taking too long due to reliance on 10m TTL caching for poolpairinfo

#### Additional comments?:
- Pagination needs to be followed in order to retrieve the full list - this is made explicit with a `while (true)`