### PR TITLE
fix(poolpair/dexprices): add denomination symbol to dexprices cache key

### DIFF
--- a/src/module.api/poolpair.controller.e2e.ts
+++ b/src/module.api/poolpair.controller.e2e.ts
@@ -5,8 +5,6 @@ import { createTestingApp, stopTestingApp, waitForIndexedHeight } from '@src/e2e
 import { addPoolLiquidity, createPoolPair, createToken, getNewAddress, mintTokens } from '@defichain/testing'
 import { NotFoundException } from '@nestjs/common'
 import { BigNumber } from 'bignumber.js'
-import { SemaphoreCache } from '@src/module.api/cache/semaphore.cache'
-import { CacheOption } from '@src/module.api/cache/global.cache'
 
 const container = new MasterNodeRegTestContainer()
 let app: NestFastifyApplication
@@ -19,14 +17,6 @@ beforeAll(async () => {
 
   app = await createTestingApp(container)
   controller = app.get(PoolPairController)
-
-  // Disable cache during tests
-  const cache = app.get(SemaphoreCache)
-  jest.spyOn(cache, 'get').mockImplementation(
-    async (key: string, fetch: () => Promise<any>, options: CacheOption = {}): Promise<any> => {
-      return await fetch()
-    }
-  )
 
   await waitForIndexedHeight(app, 100)
 

--- a/src/module.api/poolpair.prices.service.ts
+++ b/src/module.api/poolpair.prices.service.ts
@@ -21,7 +21,7 @@ export class PoolPairPricesService {
 
   async listDexPrices (denominationSymbol: string): Promise<DexPricesResult> {
     const cached = await this.cache.get<DexPricesResult>(
-      'LATEST_DEX_PRICES',
+      'LATEST_DEX_PRICES_' + denominationSymbol,
       async () => await this._listDexPrices(denominationSymbol),
       {
         ttl: 30 // 30s


### PR DESCRIPTION
#### What kind of PR is this?:
/kind fix

#### What this PR does / why we need it:
- Fixes the issue of `/dexprices?denomination=SYMBOL` ignoring SYMBOL and returning wrong result
- Issue was that the denomination symbol wasn't being added to `listDexPrices` cache key, so all queries were hitting 'LIST_DEX_PRICES' regardless of the denomination symbol
