### PR TITLE
fix(poolpair/pathfinding): always use direct path if available

### DIFF
--- a/src/module.api/poolpair.controller.e2e.ts
+++ b/src/module.api/poolpair.controller.e2e.ts
@@ -414,7 +414,7 @@ describe('get best path', () => {
     })
   })
 
-  it('should get best of two possible swap paths', async () => {
+  it('should return direct path even if composite swap paths has greater return', async () => {
     // 1 J = 7 K
     // 1 J = 2 L = 8 K
     const response = await controller.getBestPath('10', '11')
@@ -431,21 +431,14 @@ describe('get best path', () => {
       },
       bestPath: [
         {
-          symbol: 'J-L',
-          poolPairId: '22',
-          priceRatio: { ab: '0.50000000', ba: '2.00000000' },
+          symbol: 'J-K',
+          poolPairId: '21',
+          priceRatio: { ab: '0.14285714', ba: '7.00000000' },
           tokenA: { id: '10', symbol: 'J', displaySymbol: 'dJ' },
-          tokenB: { id: '12', symbol: 'L', displaySymbol: 'dL' }
-        },
-        {
-          symbol: 'L-K',
-          poolPairId: '23',
-          priceRatio: { ab: '0.25000000', ba: '4.00000000' },
-          tokenA: { id: '12', symbol: 'L', displaySymbol: 'dL' },
           tokenB: { id: '11', symbol: 'K', displaySymbol: 'dK' }
         }
       ],
-      estimatedReturn: '8.00000000'
+      estimatedReturn: '7.00000000'
     })
   })
 

--- a/src/module.api/poolswap.pathfinding.service.ts
+++ b/src/module.api/poolswap.pathfinding.service.ts
@@ -52,6 +52,21 @@ export class PoolSwapPathFindingService {
       paths
     } = await this.getAllSwapPaths(fromTokenId, toTokenId)
 
+    // always use direct path if available
+    for (const path of paths) {
+      if (path.length === 1) {
+        return {
+          fromToken: fromToken,
+          toToken: toToken,
+          bestPath: path,
+          estimatedReturn: formatNumber(
+            computeReturnInDestinationToken(path, fromTokenId)
+          ) // denoted in toToken
+        }
+      }
+    }
+
+    // otherwise, search for the best path based on return
     let bestPath: SwapPathPoolPair[] = []
     let bestReturn = new BigNumber(0)
 
@@ -62,6 +77,7 @@ export class PoolSwapPathFindingService {
         bestPath = path
       }
     }
+
     return {
       fromToken: fromToken,
       toToken: toToken,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
/kind fix

#### What this PR does / why we need it:
- Change /poolpairs/paths/best/from/1/to/0 to return direct path if a direct poolpair is available